### PR TITLE
Add image rendering and external image storage for Grafana

### DIFF
--- a/modules/grafana/external_image_storage.tf
+++ b/modules/grafana/external_image_storage.tf
@@ -1,0 +1,6 @@
+resource "aws_s3_bucket" "external_image_storage" {
+  bucket = "${var.prefix}-grafana-image-storage"
+  acl    = "private"
+
+  tags = var.tags
+}

--- a/modules/grafana/iam.tf
+++ b/modules/grafana/iam.tf
@@ -9,3 +9,22 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_read_access_policy_attachm
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess"
   role       = aws_iam_role.task_role.name
 }
+
+resource "aws_iam_policy" "s3_access_policy" {
+  name = "${var.prefix}-grafana-s3-access"
+
+  policy = data.template_file.s3_access_policy.rendered
+}
+
+data "template_file" "s3_access_policy" {
+  template = file("${path.module}/policies/s3_access_policy.template.json")
+
+  vars = {
+    bucket = aws_s3_bucket.external_image_storage.bucket
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {
+  policy_arn = aws_iam_policy.s3_access_policy.arn
+  role       = aws_iam_role.task_role.name
+}

--- a/modules/grafana/policies/s3_access_policy.template.json
+++ b/modules/grafana/policies/s3_access_policy.template.json
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "Statement",
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject",
+        "s3:PutObjectAcl"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket}/*",
+        "arn:aws:s3:::${bucket}"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This PR enables Grafana to render images using Grafana Image Renderer as a remote HTTP rendering service i.e. another container sitting beside it in the Fargate task. We then use AWS S3 to store the rendered image for usage when sending alert notifications.