### PR TITLE
Update Terraform linting to use script from config repository

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,4 @@ jobs:
         with:
           tflint_version: latest
       - name: Run linter
-        run: |
-          tflint
-          tflint modules/blackbox_exporter
-          tflint modules/corsham_bastion
-          tflint modules/grafana
-          tflint modules/monitoring_platform
-          tflint modules/prometheus
-          tflint modules/snmp_exporter
+        run: ./scripts/lint_terraform.sh

--- a/scripts/lint_terraform.sh
+++ b/scripts/lint_terraform.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+for TFFILE in $(find . -name '*.tf');
+do
+  tflint $TFFILE
+done;


### PR DESCRIPTION
Currently in this repo to lint Terraform files in CI, we've hardcoded the directories required. This nicks the script that finds `.tf` files and lints them we have in our config repo and uses in this repo.