### PR TITLE
Redirect http to https

### DIFF
--- a/modules/grafana/load_balancer.tf
+++ b/modules/grafana/load_balancer.tf
@@ -37,10 +37,13 @@ resource "aws_alb_listener" "front_end_grafana" {
 
   depends_on = [aws_acm_certificate.grafana]
 }
-resource "aws_lb_listener_rule" "redirect_http_to_https" {
-  listener_arn = aws_alb_listener.front_end_grafana.arn
 
-  action {
+resource "aws_alb_listener" "redirect_http_to_https" {
+  load_balancer_arn = aws_alb.main_grafana.id
+  port              = "80"
+  protocol          = "HTTP"
+
+  default_action {
     type = "redirect"
 
     redirect {
@@ -48,10 +51,5 @@ resource "aws_lb_listener_rule" "redirect_http_to_https" {
       protocol    = "HTTPS"
       status_code = "HTTP_301"
     }
-  }
-
-  condition {
-    field  = "host-header"
-    values = [aws_route53_record.grafana.name]
   }
 }

--- a/modules/grafana/load_balancer.tf
+++ b/modules/grafana/load_balancer.tf
@@ -37,3 +37,21 @@ resource "aws_alb_listener" "front_end_grafana" {
 
   depends_on = [aws_acm_certificate.grafana]
 }
+resource "aws_lb_listener_rule" "redirect_http_to_https" {
+  listener_arn = aws_alb_listener.front_end_grafana.arn
+
+  action {
+    type = "redirect"
+
+    redirect {
+      port        = "443"
+      protocol    = "HTTPS"
+      status_code = "HTTP_301"
+    }
+  }
+
+  condition {
+    field  = "host-header"
+    values = [aws_route53_record.grafana.name]
+  }
+}

--- a/modules/grafana/security_groups.tf
+++ b/modules/grafana/security_groups.tf
@@ -32,6 +32,13 @@ resource "aws_security_group" "lb_grafana" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
+  ingress {
+    protocol    = "tcp"
+    from_port   = "80"
+    to_port     = "80"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
   egress {
     from_port   = 0
     to_port     = 0


### PR DESCRIPTION
- Added an ALB listener that redirects traffic from HTTP to HTTPS for grafana
- Added a security group rule to allow HTTP traffic into the ALB so it can redirect to HTTPS