### PR TITLE
Thanos compactor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -131,6 +131,8 @@ module "grafana" {
 module "prometheus" {
   source = "./modules/prometheus"
 
+  enable_compactor = "false"
+
   aws_region  = var.aws_region
   prefix_pttp = module.label_pttp.id
   prefix      = module.label.id

--- a/modules/prometheus/service.tf
+++ b/modules/prometheus/service.tf
@@ -178,7 +178,7 @@ resource "aws_ecs_task_definition" "thanos_compactor_task_definition" {
     "command": [
       "compact",
       "--data-dir=/tmp/thanos-compact",
-      "--objstore.config=${data.template_file.storage_config.rendered}",
+      "--objstore.config=${local.storage_config}",
       "--wait",
       "--wait-interval=5m"
     ],

--- a/modules/prometheus/service.tf
+++ b/modules/prometheus/service.tf
@@ -200,6 +200,8 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "thanos_compactor_ecs_service" {
+  count = var.enable_compactor == "true" ? 1 : 0 
+
   name = "${var.prefix_pttp}-comp-ecs-service"
 
   launch_type      = "FARGATE"

--- a/modules/prometheus/service.tf
+++ b/modules/prometheus/service.tf
@@ -200,7 +200,7 @@ DEFINITION
 }
 
 resource "aws_ecs_service" "thanos_compactor_ecs_service" {
-  count = var.enable_compactor == "true" ? 1 : 0 
+  count = var.enable_compactor == "true" ? 1 : 0
 
   name = "${var.prefix_pttp}-comp-ecs-service"
 

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -57,3 +57,9 @@ variable "execution_role_arn" {
 variable "fargate_count" {
   description = "Number of docker containers to run"
 }
+
+// This flag can be removed once everying is migrated over to the correct cidr range
+// we don't want to run two instances against the same bucket whilst everything is doubled up
+variable "enable_compactor" {
+  type = string
+}

--- a/mojo.tf
+++ b/mojo.tf
@@ -84,6 +84,8 @@ module "grafana_v2" {
 module "prometheus_v2" {
   source = "./modules/prometheus"
 
+  enable_compactor = true
+
   aws_region  = var.aws_region
   prefix_pttp = module.label_mojo.id
   prefix      = module.label_mojo.id

--- a/mojo.tf
+++ b/mojo.tf
@@ -84,7 +84,7 @@ module "grafana_v2" {
 module "prometheus_v2" {
   source = "./modules/prometheus"
 
-  enable_compactor = true
+  enable_compactor = "true"
 
   aws_region  = var.aws_region
   prefix_pttp = module.label_mojo.id


### PR DESCRIPTION
Adds [thanos compactor](https://github.com/thanos-io/thanos/blob/main/docs/components/compact.md) to our ECS cluster. This ensures that long term metric data is stored efficiently in s3. 