### PR TITLE
Pull selenium image from aws ecr repository in shared services account

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -9,6 +9,7 @@ env:
     TF_VAR_owner_email: pttp@justice.gov.uk
     TF_VAR_enable_critical_notifications: true
   parameter-store:
+    SHARED_SERVICES_ACCOUNT_ID: "/codebuild/staff_device_shared_services_account_id"
     TF_VAR_assume_role: "/codebuild/pttp-ci-ima-pipeline/$ENV/assume_role"
     TF_VAR_grafana_db_name: "/codebuild/pttp-ci-ima-pipeline/$ENV/grafana_db_name"
     TF_VAR_grafana_db_endpoint: "/codebuild/pttp-ci-ima-pipeline/$ENV/grafana_db_endpoint"
@@ -53,6 +54,7 @@ phases:
 
   post_build:
     commands:
+      - ./scripts/authenticate_docker.sh
       - cd test/
       - docker-compose up -d
       - bundle install

--- a/scripts/authenticate_docker.sh
+++ b/scripts/authenticate_docker.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com

--- a/test/docker-compose.yml
+++ b/test/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   chrome:
-    image: selenium/node-chrome:3.14.0-gallium
+    image: ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/selenium-node-chrome:selenium-node-chrome-3-14-0-gallium
     volumes:
       - /dev/shm:/dev/shm
     depends_on:
@@ -10,6 +10,6 @@ services:
       HUB_HOST: hub
 
   hub:
-    image: selenium/hub:3.14.0-gallium
+    image: ${SHARED_SERVICES_ACCOUNT_ID}.dkr.ecr.eu-west-2.amazonaws.com/selenium-hub:selenium-hub-3-14-0-gallium
     ports:
       - "4444:4444"

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
-domain="`grep -m 1 'vpn_hosted_zone_domain' ../terraform.tfvars`"
-prefix="`grep -m 1 'domain_prefix' ../terraform.tfvars`"
-username="`grep -m 1 'grafana_admin_username' ../terraform.tfvars`"
-password="`grep -m 1 'grafana_admin_password' ../terraform.tfvars`"
+domain="`grep -m 1 '^vpn_hosted_zone_domain' ../terraform.tfvars`"
+prefix="`grep -m 1 '^domain_prefix' ../terraform.tfvars`"
+username="`grep -m 1 '^grafana_admin_username' ../terraform.tfvars`"
+password="`grep -m 1 '^grafana_admin_password' ../terraform.tfvars`"
 
 echo "Running rspec"
 


### PR DESCRIPTION

Changed run_test script to grep from the beginning of the line, as I often have dev & my workspace vars, with one commented out.