### PR TITLE
Define the default security group in terraform

### DIFF
--- a/modules/monitoring_platform/network.tf
+++ b/modules/monitoring_platform/network.tf
@@ -7,6 +7,10 @@ resource "aws_vpc" "main" {
   tags = var.tags
 }
 
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.main.id
+}
+
 resource "aws_subnet" "private" {
   count             = var.az_count
   vpc_id            = aws_vpc.main.id


### PR DESCRIPTION
Ticket [PTTP-2885](https://dsdmoj.atlassian.net/browse/PTTP-2885)

When specifying the [terraform default security group](https://dsdmoj.atlassian.net/browse/PTTP-2885) in terraform, be default on inbound or outbound rules will be created. So bringing this under terraforms control should close the default security group to all traffic.