### PR TITLE
Manage auth for the EKS cluster manually

### DIFF
--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -4,7 +4,7 @@ data "aws_eks_cluster_auth" "monitoring_alerting_cluster" {
 }
 
 resource "aws_iam_role" "cluster_role" {
-  name = "${var.prefix}-cluster-role"
+  name               = "${var.prefix}-cluster-role"
   assume_role_policy = <<POLICY
 {
   "Version": "2012-10-17",
@@ -19,7 +19,7 @@ resource "aws_iam_role" "cluster_role" {
   ]
 }
 POLICY
-  count = var.is_eks_enabled ? 1 : 0
+  count              = var.is_eks_enabled ? 1 : 0
 }
 
 resource "aws_iam_role_policy_attachment" "cluster_role_policy_attachment" {
@@ -33,11 +33,11 @@ resource "aws_iam_role_policy_attachment" "service_role_policy_attachment" {
   count      = var.is_eks_enabled ? 1 : 0
 }
 
-locals{
-    map_roles = [
+locals {
+  map_roles = [
     {
-      rolearn  = var.is_eks_enabled  ? aws_iam_role.cluster_role[0].arn : ""
-      username = var.is_eks_enabled  ? aws_iam_role.cluster_role[0].name : ""
+      rolearn  = var.is_eks_enabled ? aws_iam_role.cluster_role[0].arn : ""
+      username = var.is_eks_enabled ? aws_iam_role.cluster_role[0].name : ""
       groups   = ["system:masters"]
     },
   ]
@@ -50,7 +50,7 @@ module "monitoring_alerting_cluster" {
   cluster_name    = "${var.prefix}-cluster"
   cluster_version = "1.15"
   manage_aws_auth = false
-  map_roles = local.map_roles
+  map_roles       = local.map_roles
 
   subnets = aws_subnet.private.*.id
   vpc_id  = aws_vpc.main.id

--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -3,13 +3,54 @@ data "aws_eks_cluster_auth" "monitoring_alerting_cluster" {
   name  = module.monitoring_alerting_cluster.cluster_id
 }
 
+resource "aws_iam_role" "cluster_role" {
+  name = "${var.prefix}-cluster-role"
+  assume_role_policy = <<POLICY
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "eks.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+POLICY
+  count = var.is_eks_enabled ? 1 : 0
+}
+
+resource "aws_iam_role_policy_attachment" "cluster_role_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.cluster_role[0].name
+  count      = var.is_eks_enabled ? 1 : 0
+}
+resource "aws_iam_role_policy_attachment" "service_role_policy_attachment" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
+  role       = aws_iam_role.cluster_role[0].name
+  count      = var.is_eks_enabled ? 1 : 0
+}
+
+locals{
+    map_roles = [
+    {
+      rolearn  = var.is_eks_enabled  ? aws_iam_role.cluster_role[0].arn : ""
+      username = var.is_eks_enabled  ? aws_iam_role.cluster_role[0].name : ""
+      groups   = ["system:masters"]
+    },
+  ]
+}
+
 module "monitoring_alerting_cluster" {
   source          = "terraform-aws-modules/eks/aws"
   version         = "10.0.0"
   create_eks      = var.is_eks_enabled
   cluster_name    = "${var.prefix}-cluster"
   cluster_version = "1.15"
-
+  manage_aws_auth = false
+  map_roles = local.map_roles
 
   subnets = aws_subnet.private.*.id
   vpc_id  = aws_vpc.main.id


### PR DESCRIPTION
The EKS terraform module appears to have some bugs relating to the AWS auth against the cluster. We can avoid these issues by manually generating our auth roles. 