### PR TITLE
A few cluster updates

### DIFF
--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -48,9 +48,11 @@ module "monitoring_alerting_cluster" {
   version         = "10.0.0"
   create_eks      = var.is_eks_enabled
   cluster_name    = "${var.prefix}-cluster"
-  cluster_version = "1.15"
+  cluster_version = "1.16"
   manage_aws_auth = false
   map_roles       = local.map_roles
+  cluster_endpoint_private_access = true
+  cluster_enabled_log_types = ["api", "authenticator", "controllerManager"]
 
   subnets = aws_subnet.private.*.id
   vpc_id  = aws_vpc.main.id

--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -44,15 +44,15 @@ locals {
 }
 
 module "monitoring_alerting_cluster" {
-  source          = "terraform-aws-modules/eks/aws"
-  version         = "10.0.0"
-  create_eks      = var.is_eks_enabled
-  cluster_name    = "${var.prefix}-cluster"
-  cluster_version = "1.16"
-  manage_aws_auth = false
-  map_roles       = local.map_roles
+  source                          = "terraform-aws-modules/eks/aws"
+  version                         = "10.0.0"
+  create_eks                      = var.is_eks_enabled
+  cluster_name                    = "${var.prefix}-cluster"
+  cluster_version                 = "1.16"
+  manage_aws_auth                 = false
+  map_roles                       = local.map_roles
   cluster_endpoint_private_access = true
-  cluster_enabled_log_types = ["api", "authenticator", "controllerManager"]
+  cluster_enabled_log_types       = ["api", "authenticator", "controllerManager"]
 
   subnets = aws_subnet.private.*.id
   vpc_id  = aws_vpc.main.id

--- a/modules/monitoring_platform/outputs.tf
+++ b/modules/monitoring_platform/outputs.tf
@@ -29,3 +29,7 @@ output "cluster_id" {
 output "cluster_endpoint" {
   value = module.monitoring_alerting_cluster.cluster_endpoint
 }
+
+output "cluster_role_arn" {
+  value = module.monitoring_alerting_cluster.cluster_iam_role_arn
+}

--- a/mojo_outputs.tf
+++ b/mojo_outputs.tf
@@ -54,3 +54,7 @@ output "eks_cluster_endpoint" {
   value = module.monitoring_platform_v2.cluster_endpoint
 }
 
+
+output "eks_cluster_role_arn" {
+  value = module.monitoring_platform_v2.cluster_role_arn
+}


### PR DESCRIPTION
- Upgrade version of eks module - a minimum of 1.16 is required for prom helm charts
- enable private access to the cluster
- enable logging of the cluster to cloudwatch
- output the role arn as this is needed to manually create a config map