### PR TITLE
replace-provider on terraform remote state

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -50,6 +50,12 @@ phases:
       - terraform providers
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
+      - terraform state replace-provider -- -/aws registry.terraform.io/hashicorp/aws
+      - terraform state replace-provider -- -/kubernetes registry.terraform.io/hashicorp/kubernetes
+      - terraform state replace-provider -- -/local registry.terraform.io/hashicorp/local
+      - terraform state replace-provider -- -/null registry.terraform.io/hashicorp/null
+      - terraform state replace-provider -- -/random registry.terraform.io/hashicorp/random
+      - terraform state replace-provider -- -/template registry.terraform.io/hashicorp/template
       - terraform apply --auto-approve -no-color
       - ./scripts/publish_terraform_outputs.sh
 


### PR DESCRIPTION
Since the terraform upgrade from 0.12.x to 0.13.x some providers sources need to be manually replaced on the remote state file.
more information: https://www.terraform.io/upgrade-guides/0-13.html#why-do-i-see-provider-during-init-