### PR TITLE
Explicitly specific which version of Fargate to use

### DIFF
--- a/modules/grafana/service.tf
+++ b/modules/grafana/service.tf
@@ -92,10 +92,11 @@ resource "aws_ecs_task_definition" "grafana_task_definition" {
 resource "aws_ecs_service" "grafana_ecs_service" {
   name = "${var.prefix_pttp}-grafana-ecs-service"
 
-  launch_type     = "FARGATE"
-  desired_count   = var.fargate_count
-  cluster         = var.cluster_id
-  task_definition = aws_ecs_task_definition.grafana_task_definition.arn
+  platform_version = "1.3.0"
+  launch_type      = "FARGATE"
+  desired_count    = var.fargate_count
+  cluster          = var.cluster_id
+  task_definition  = aws_ecs_task_definition.grafana_task_definition.arn
 
   network_configuration {
     subnets         = var.private_subnet_ids


### PR DESCRIPTION
When spinning up new environments we are running into issues when using the new 1.4.0 version. So specifying 1.3.0 here to ensure that version is used. 