### PR TITLE
removes terraform state replace-provider commands

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -50,12 +50,6 @@ phases:
       - terraform providers
       - terraform workspace new $ENV || true
       - terraform workspace select $ENV
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/aws registry.terraform.io/hashicorp/aws
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/kubernetes registry.terraform.io/hashicorp/kubernetes
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/local registry.terraform.io/hashicorp/local
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/null registry.terraform.io/hashicorp/null
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/random registry.terraform.io/hashicorp/random
-      - terraform state replace-provider -auto-approve registry.terraform.io/-/template registry.terraform.io/hashicorp/template
       - terraform apply --auto-approve -no-color
       - ./scripts/publish_terraform_outputs.sh
 


### PR DESCRIPTION
terraform state replace-provider commands were temporarily needed to help with the terraform upgrade from 0.12.x to major version 0.13.x. 
Since, Terraform is now upgraded to 0.13.x, those replace-provider commands are removed.