### PR TITLE
Upgrading tf version for database folder

### DIFF
--- a/database/main.tf
+++ b/database/main.tf
@@ -1,4 +1,8 @@
 
+provider "aws" {
+  region  = var.aws_region
+
+}
 
 module "label" {
   version = "0.24.0"

--- a/database/main.tf
+++ b/database/main.tf
@@ -1,16 +1,7 @@
-terraform {
-  required_version = "> 0.12.0"
-}
 
-provider "aws" {
-  alias   = "env"
-  version = "~> 2.68"
-  profile = var.environment
-
-}
 
 module "label" {
-  version = "0.16.0"
+  version = "0.24.0"
   source  = "cloudposse/label/null"
 
   delimiter = "-"

--- a/database/versions.tf
+++ b/database/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = "> 0.13.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.32.0"
+    }
+  }
+}


### PR DESCRIPTION
The database folder is used for local development to create a grafana database.  This PR upgrades the terraform version to bring in line with the main repo.