### PR TITLE
adds deployment of thanos compactor to kubernets

### DIFF
--- a/kubernetes/prometheus-thanos/templates/thanos-compactor-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/thanos-compactor-deployment.yaml
@@ -1,0 +1,40 @@
+{{- if .Values.thanos.compactor.enabled }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: thanos-compactor-deployment
+  labels:
+    app: thanos-compactor
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: thanos-compactor
+  template:
+    metadata:
+      labels:
+        app: thanos-compactor
+    spec:
+      containers:
+        - name: thanos-compactor
+          image: {{ .Values.thanos.image }}
+          command: ["thanos", "compact"]
+          args:
+            - "--log.level=debug"
+            - "--data-dir=/tmp/thanos-compact"
+            - "--objstore.config={
+              type: S3,
+              config: { 
+                bucket: {{ .Values.prometheusThanosStorageBucket.bucketName }},
+                endpoint: {{ .Values.prometheusThanosStorageBucket.endpoint }},
+                insecure: false,
+                signature_version2: false,
+                sse_config: {
+                  type: SSE-KMS,
+                  kms_key_id: {{ .Values.prometheusThanosStorageBucket.kmsKeyId }}
+                }
+              } 
+            }"
+            - "--wait"
+            - "--wait-interval=5m"
+{{- end }}

--- a/kubernetes/prometheus-thanos/values.yaml
+++ b/kubernetes/prometheus-thanos/values.yaml
@@ -2,6 +2,8 @@ prometheus:
   image: ""
 thanos:
   image: "quay.io/thanos/thanos:v0.15.0"
+  compactor:
+    enabled: false
 prometheusThanosStorageBucket:
   bucketName: ""
   endpoint: "s3.eu-west-2.amazonaws.com"

--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -65,3 +65,17 @@ module "monitoring_alerting_cluster" {
     },
   ]
 }
+
+resource "aws_iam_policy" "s3_access_policy" {
+  name = "${var.prefix}-thanos-worker-policy"
+
+  policy = templatefile("${path.module}/policies/s3_access_policy.template.json", {
+    bucket = var.storage_bucket_arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {
+  policy_arn = aws_iam_policy.s3_access_policy.arn
+  role       = module.monitoring_alerting_cluster.worker_iam_role_name
+  count      = var.is_eks_enabled ? 1 : 0
+}

--- a/modules/monitoring_platform/policies/s3_access_policy.template.json
+++ b/modules/monitoring_platform/policies/s3_access_policy.template.json
@@ -1,0 +1,19 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement",
+            "Effect": "Allow",
+            "Action": [
+                "s3:ListBucket",
+                "s3:GetObject",
+                "s3:DeleteObject",
+                "s3:PutObject"
+            ],
+            "Resource": [
+                "arn:aws:s3:::${bucket}/*",
+                "arn:aws:s3:::${bucket}"
+            ]
+        }
+    ]
+}

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -42,6 +42,6 @@ variable "is_eks_enabled" {
 }
 
 variable "storage_bucket_arn" {
-  type = string
+  type    = string
   default = ""
 }

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -40,3 +40,8 @@ variable "is_eks_enabled" {
   type    = bool
   default = false
 }
+
+variable "storage_bucket_arn" {
+  type = string
+  default = ""
+}

--- a/mojo.tf
+++ b/mojo.tf
@@ -20,6 +20,7 @@ module "monitoring_platform_v2" {
   public_subnet_cidr_blocks  = ["10.180.102.0/25", "10.180.102.128/25", "10.180.103.0/25"]
 
   is_eks_enabled = true
+  storage_bucket_arn = module.prometheus-thanos-storage.bucket_arn
 
   providers = {
     aws = aws.env

--- a/mojo.tf
+++ b/mojo.tf
@@ -19,7 +19,7 @@ module "monitoring_platform_v2" {
   private_subnet_cidr_blocks = ["10.180.100.0/25", "10.180.100.128/25", "10.180.101.0/25"]
   public_subnet_cidr_blocks  = ["10.180.102.0/25", "10.180.102.128/25", "10.180.103.0/25"]
 
-  is_eks_enabled = true
+  is_eks_enabled     = true
   storage_bucket_arn = module.prometheus-thanos-storage.bucket_arn
 
   providers = {


### PR DESCRIPTION
adds conditional deployment for the compactor container
also adds s3 access policy to the worker iam role

Notes:
we have set the flag to deploy compactor to `false` so that two instances of thanos compactor do not write to the same s3 bucket at the same time.