### PR TITLE
Replace deprecated API

### DIFF
--- a/kubernetes/prometheus-thanos/templates/prometheus-ingress.yaml
+++ b/kubernetes/prometheus-thanos/templates/prometheus-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: prometheus-ingress
@@ -9,6 +9,9 @@ spec:
   - http:
       paths:
       - path: /prometheus
+        pathType: Exact
         backend:
-          serviceName: thanos-querier
-          servicePort: 10902
+          service:
+              name: thanos-querier
+              port:
+                number: 10902


### PR DESCRIPTION
The API version `extensions/v1beta1` has is being deprecated, replacing here with the API `networking.k8s.io/v1`