### PR TITLE
The cluster role we created isn't used in the eks module

### DIFF
--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -1,48 +1,3 @@
-data "aws_eks_cluster_auth" "monitoring_alerting_cluster" {
-  count = var.is_eks_enabled ? 1 : 0
-  name  = module.monitoring_alerting_cluster.cluster_id
-}
-
-resource "aws_iam_role" "cluster_role" {
-  name               = "${var.prefix}-cluster-role"
-  assume_role_policy = <<POLICY
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Service": "eks.amazonaws.com"
-      },
-      "Action": "sts:AssumeRole"
-    }
-  ]
-}
-POLICY
-  count              = var.is_eks_enabled ? 1 : 0
-}
-
-resource "aws_iam_role_policy_attachment" "cluster_role_policy_attachment" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
-  role       = aws_iam_role.cluster_role[0].name
-  count      = var.is_eks_enabled ? 1 : 0
-}
-resource "aws_iam_role_policy_attachment" "service_role_policy_attachment" {
-  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
-  role       = aws_iam_role.cluster_role[0].name
-  count      = var.is_eks_enabled ? 1 : 0
-}
-
-locals {
-  map_roles = [
-    {
-      rolearn  = var.is_eks_enabled ? aws_iam_role.cluster_role[0].arn : ""
-      username = var.is_eks_enabled ? aws_iam_role.cluster_role[0].name : ""
-      groups   = ["system:masters"]
-    },
-  ]
-}
-
 module "monitoring_alerting_cluster" {
   source                          = "terraform-aws-modules/eks/aws"
   version                         = "14.0.0"
@@ -50,7 +5,6 @@ module "monitoring_alerting_cluster" {
   cluster_name                    = "${var.prefix}-cluster"
   cluster_version                 = "1.19"
   manage_aws_auth                 = false
-  map_roles                       = local.map_roles
   cluster_endpoint_private_access = true
   cluster_enabled_log_types       = ["api", "authenticator", "controllerManager"]
 


### PR DESCRIPTION
When creating the eks module, we thought that setting `manage_aws_auth=false` meant we would have to create our own IAM role for the cluster.

It actually means that we have to manually upload the auth config map, which we manage in helm. 

The role we created here isn't being used by anything. 