### PR TITLE
Pause alerts script + flesh out migrate db script

### DIFF
--- a/scripts/migrate-db.sh
+++ b/scripts/migrate-db.sh
@@ -1,19 +1,38 @@
 #!/bin/bash
-## Create a new RDS db from a snapshot in moj-pttp-dev
 
-db_identifier=""
-snapshot_identifier=""
-db_subnet_group=""
-vpc_security_group_ids=""
+## Replace an RDS database with a snapshot of another database
+
+db_identifier_v1="" #identifier for the v1 database
+db_identifier_v2="" #identifier for the v2 database
+db_subnet_group="" #subnet group for v2 database
+vpc_security_group_ids="" #VPC for v2 database
+snapshot_identifier="" #name of the snapshot to temporarily be created
+
 instance_size="db.t2.medium"
 
+# Delete current V2 database
+echo "Deleting database ${db_identifier_v2}"
+aws rds delete-db-instance --db-instance-identifier $db_identifier_v2 --skip-final-snapshot
+aws rds wait db-instance-deleted --db-instance-identifier $db_identifier_v2
 
+# Create snapshot of V1 database
+echo "Creating snapshot of ${db_identifier_v1}"
+aws rds create-db-snapshot --db-snapshot-identifier $snapshot_identifier --db-instance-identifier $db_identifier_v1
+aws rds wait db-snapshot-available --db-snapshot-identifier $snapshot_identifier
 
+# Create new database from the snapshot in the V2 VPC
+echo "Recreating database ${db_identifier_v2} from snapshot"
 aws rds restore-db-instance-from-db-snapshot \
---db-instance-identifier $db_identifier \
+--db-instance-identifier $db_identifier_v2 \
 --db-snapshot-identifier $snapshot_identifier \
 --db-subnet-group-name $db_subnet_group \
 --vpc-security-group-ids $vpc_security_group_ids \
 --db-instance-class $instance_size \
 --engine postgres
 
+aws rds wait db-instance-available --db-instance-identifier $db_identifier_v2
+
+# Delete the snapshot
+echo "Deleting snapshot"
+aws rds delete-db-snapshot --db-snapshot-identifier $snapshot_identifier
+aws rds wait db-snapshot-deleted --db-snapshot-identifier $snapshot_identifier

--- a/scripts/pause_alerts.sh
+++ b/scripts/pause_alerts.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+grafana_username=""
+grafana_password=""
+grafana_url=""
+
+curl -u $grafana_username:$grafana_password -H "Content-Type:application/json" --data-binary '{"paused": true}' ${grafana_url}/api/admin/pause-all-alerts


### PR DESCRIPTION
- Added a new bash script to pause all the alerts for grafana
- Changed the migrate db script to
  1, delete the current database that's sitting in the new VPC
  2, Create a snapshot of the database sitting in the old VPC
  3, recreate the database sitting in the new VPC from this snapshot
  4, delete the snapshot that was just created

This should make it quicker to switch over the databases when we need to. 

FYI - when doing this, grafana in the new VPC will take on the configuration of the one in the old VPC which will cause it to fire off alerts as the Prometheus URL in data sources will be the wrong one.