### PR TITLE
Pttp 3735/deploy alertmanager in kubernetes

### DIFF
--- a/kubernetes/prometheus-thanos/templates/alertmanager-configmap.yaml
+++ b/kubernetes/prometheus-thanos/templates/alertmanager-configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: alertmanager-configmap
+data:
+  alertmanager.yml: |
+    global:
+      # The API URL to use for Slack notifications.
+      slack_api_url: "https://hooks.slack.com/services/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"
+      # The root route with all parameters, which are inherited by the child
+    # routes if they are not overwritten.
+    route:
+      receiver: 'default-receiver'
+      group_wait: 30s
+      group_interval: 5m
+      repeat_interval: 4h
+      group_by: ['...']
+      # All alerts that do not match the following child routes
+      # will remain at the root node and be dispatched to 'default-receiver'.
+    receivers:
+      - name: 'default-receiver'
+
+

--- a/kubernetes/prometheus-thanos/templates/alertmanager-configmap.yaml
+++ b/kubernetes/prometheus-thanos/templates/alertmanager-configmap.yaml
@@ -4,19 +4,12 @@ metadata:
   name: alertmanager-configmap
 data:
   alertmanager.yml: |
-    global:
-      # The API URL to use for Slack notifications.
-      slack_api_url: "https://hooks.slack.com/services/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"
-      # The root route with all parameters, which are inherited by the child
-    # routes if they are not overwritten.
     route:
       receiver: 'default-receiver'
       group_wait: 30s
       group_interval: 5m
       repeat_interval: 4h
       group_by: ['...']
-      # All alerts that do not match the following child routes
-      # will remain at the root node and be dispatched to 'default-receiver'.
     receivers:
       - name: 'default-receiver'
 

--- a/kubernetes/prometheus-thanos/templates/alertmanager-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/alertmanager-deployment.yaml
@@ -17,5 +17,20 @@ spec:
       containers:
       - name: alertmanager
         image: {{ .Values.alertmanager.image }}:latest
+        command: ["alertmanager"]
+        args: 
+          - "--config.file=/config/alertmanager.yml"
         ports:
         - containerPort: 9093
+          protocol: TCP
+        volumeMounts:
+        - name: configuration
+          mountPath: "/config"
+          readOnly: true
+      volumes:
+      - name: configuration
+        configMap:
+          name: alertmanager-configmap
+          items:
+          - key: "alertmanager.yml"
+            path: "alertmanager.yml"

--- a/kubernetes/prometheus-thanos/templates/alertmanager-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/alertmanager-deployment.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-alertmanager
+  labels:
+    app: alertmanager
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: alertmanager
+  template:
+    metadata:
+      labels:
+        app: alertmanager
+    spec:
+      containers:
+      - name: alertmanager
+        image: {{ .Values.alertmanager.image }}:latest
+        ports:
+        - containerPort: 9093

--- a/kubernetes/prometheus-thanos/templates/alertmanager-service.yaml
+++ b/kubernetes/prometheus-thanos/templates/alertmanager-service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-alertmanager
+spec:
+  selector:
+    app: alertmanager
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9093
+      targetPort: 9093

--- a/kubernetes/prometheus-thanos/templates/prometheus-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/prometheus-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: prometheus-deployment
+  name: {{ .Release.Name }}-prometheus
   labels:
     app: prometheus
 spec:

--- a/kubernetes/prometheus-thanos/templates/prometheus-ingress.yaml
+++ b/kubernetes/prometheus-thanos/templates/prometheus-ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: prometheus-ingress
+  name: {{ .Release.Name }}-prometheus
   annotations:
     nginx.ingress.kubernetes.io/rewrite-target: /
 spec:

--- a/kubernetes/prometheus-thanos/templates/thanos-compactor-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/thanos-compactor-deployment.yaml
@@ -16,7 +16,7 @@ spec:
         app: thanos-compactor
     spec:
       containers:
-        - name: thanos-compactor
+        - name: {{ .Release.Name }}-thanos-compactor
           image: {{ .Values.thanos.image }}
           command: ["thanos", "compact"]
           args:

--- a/kubernetes/prometheus-thanos/templates/thanos-querier-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/thanos-querier-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: thanos-querier-deployment
+  name: {{ .Release.Name }}-thanos-querier
   labels:
     app: thanos-querier
 spec:

--- a/kubernetes/prometheus-thanos/templates/thanos-receiver-deployment.yaml
+++ b/kubernetes/prometheus-thanos/templates/thanos-receiver-deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: thanos-receiver-deployment
+  name: {{ .Release.Name }}-thanos-receiver
   labels:
     app: thanos-receiver
 spec:

--- a/kubernetes/prometheus-thanos/templates/thanos-receiver-service.yaml
+++ b/kubernetes/prometheus-thanos/templates/thanos-receiver-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: thanos-receiver
+  name: {{ .Release.Name }}-thanos-receiver
 spec:
   selector:
     app: thanos-receiver

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -29,8 +29,13 @@ helm upgrade --install --atomic mojo-$env-ima-configmap ./kubernetes/auth-config
 
 # DEPLOY PROMETHEUS
 echo "Deploying Prometheus"
-helm upgrade --install --atomic mojo-$env-ima-prometheus-thanos ./kubernetes/prometheus-thanos --set \
+helm upgrade --install mojo-$env-ima ./kubernetes/prometheus-thanos --set \
 prometheus.image=$prometheus_image_repo,\
+alertmanager.image=prom/alertmanager,\
 prometheusThanosStorageBucket.bucketName=$prometheus_thanos_storage_bucket_name,\
 prometheusThanosStorageBucket.kmsKeyId=$prometheus_thanos_storage_kms_key_id,\
 thanos.image=$TF_VAR_thanos_image_repository_url
+
+# Display all Pods
+echo "List of Pods:"
+kubectl get pods

--- a/scripts/deploy_kubernetes.sh
+++ b/scripts/deploy_kubernetes.sh
@@ -29,7 +29,7 @@ helm upgrade --install --atomic mojo-$env-ima-configmap ./kubernetes/auth-config
 
 # DEPLOY PROMETHEUS
 echo "Deploying Prometheus"
-helm upgrade --install mojo-$env-ima ./kubernetes/prometheus-thanos --set \
+helm upgrade --install --atomic mojo-$env-ima ./kubernetes/prometheus-thanos --set \
 prometheus.image=$prometheus_image_repo,\
 alertmanager.image=prom/alertmanager,\
 prometheusThanosStorageBucket.bucketName=$prometheus_thanos_storage_bucket_name,\


### PR DESCRIPTION
Added a service and deployment for alertmanager. The configuration for alertmanager is held in a configmap which we mount onto the pod.

We haven't configured any "notification channels" as this was out of scope for the ticket but have tested that when an alert goes off in prometheus we can view it in the alert manager UI, by using port forwarding.

also some tidy up...
 - updates names in all templates to include `ReleaseName` in pods names
 - removes `deployment` word from pods names