### PR TITLE
PTTP-3589 Enable ELBv2 access logging to AWS S3

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -100,6 +100,23 @@ module "grafana" {
 
   storage_bucket_arn = module.grafana-image-storage.bucket_arn
 
+  lb_access_logging_bucket_name = module.grafana_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "grafana_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "grafana-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
   providers = {
     aws = aws.env
   }
@@ -129,6 +146,23 @@ module "prometheus" {
   storage_key_arn    = module.prometheus-thanos-storage.kms_key_arn
   storage_key_id     = module.prometheus-thanos-storage.kms_key_id
 
+  lb_access_logging_bucket_name = module.prometheus_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "prometheus_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "prometheus-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
   providers = {
     aws = aws.env
   }
@@ -148,6 +182,23 @@ module "snmp_exporter" {
   private_subnet_ids = module.monitoring_platform.private_subnet_ids
 
   execution_role_arn = module.monitoring_platform.execution_role_arn
+
+  lb_access_logging_bucket_name = module.snmp_exporter_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "snmp_exporter_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "snmp-exporter-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
 
   providers = {
     aws = aws.env
@@ -169,11 +220,27 @@ module "blackbox_exporter" {
 
   execution_role_arn = module.monitoring_platform.execution_role_arn
 
+  lb_access_logging_bucket_name = module.blackbox_exporter_lb_access_logging.bucket_name
+
   providers = {
     aws = aws.env
   }
 }
 
+module "blackbox_exporter_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "blackbox-exporter-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
+  providers = {
+    aws = aws.env
+  }
+}
 
 module "s3_access_logging" {
   source = "./modules/s3_bucket"
@@ -188,7 +255,6 @@ module "s3_access_logging" {
     aws = aws.env
   }
 }
-
 
 module "prometheus-thanos-storage" {
   source = "./modules/s3_bucket"
@@ -219,7 +285,6 @@ module "grafana-image-storage" {
     target_bucket = module.s3_access_logging.bucket_name
   }
   
-
   providers = {
     aws = aws.env
   }

--- a/main.tf
+++ b/main.tf
@@ -110,11 +110,11 @@ module "grafana" {
 module "grafana_lb_access_logging" {
   source = "./modules/s3_bucket"
 
-  name               = "grafana-lb-access-logging"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "grafana-lb-access-logging"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -156,11 +156,11 @@ module "prometheus" {
 module "prometheus_lb_access_logging" {
   source = "./modules/s3_bucket"
 
-  name               = "prometheus-lb-access-logging"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "prometheus-lb-access-logging"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -193,11 +193,11 @@ module "snmp_exporter" {
 module "snmp_exporter_lb_access_logging" {
   source = "./modules/s3_bucket"
 
-  name               = "snmp-exporter-lb-access-logging"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "snmp-exporter-lb-access-logging"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -230,11 +230,11 @@ module "blackbox_exporter" {
 module "blackbox_exporter_lb_access_logging" {
   source = "./modules/s3_bucket"
 
-  name               = "blackbox-exporter-lb-access-logging"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "blackbox-exporter-lb-access-logging"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -259,9 +259,9 @@ module "s3_access_logging" {
 module "prometheus-thanos-storage" {
   source = "./modules/s3_bucket"
 
-  name               = "thanos-storage"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
+  name        = "thanos-storage"
+  prefix_pttp = module.label_pttp.id
+  tags        = module.label_pttp.tags
 
   logging = {
     target_bucket = module.s3_access_logging.bucket_name
@@ -284,7 +284,7 @@ module "grafana-image-storage" {
   logging = {
     target_bucket = module.s3_access_logging.bucket_name
   }
-  
+
   providers = {
     aws = aws.env
   }

--- a/modules/blackbox_exporter/load_balancer.tf
+++ b/modules/blackbox_exporter/load_balancer.tf
@@ -5,6 +5,12 @@ resource "aws_alb" "main_blackbox_exporter" {
   subnets         = var.private_subnet_ids
   security_groups = [aws_security_group.lb_blackbox_exporter.id]
 
+  access_logs {
+   bucket  = var.lb_access_logging_bucket_name
+   prefix  = "grafana_access_logs"
+   enabled = true
+  }
+
   tags = var.tags
 }
 

--- a/modules/blackbox_exporter/load_balancer.tf
+++ b/modules/blackbox_exporter/load_balancer.tf
@@ -6,9 +6,9 @@ resource "aws_alb" "main_blackbox_exporter" {
   security_groups = [aws_security_group.lb_blackbox_exporter.id]
 
   access_logs {
-   bucket  = var.lb_access_logging_bucket_name
-   prefix  = "grafana_access_logs"
-   enabled = true
+    bucket  = var.lb_access_logging_bucket_name
+    prefix  = "grafana_access_logs"
+    enabled = true
   }
 
   tags = var.tags

--- a/modules/blackbox_exporter/variables.tf
+++ b/modules/blackbox_exporter/variables.tf
@@ -56,3 +56,10 @@ variable "fargate_count" {
   description = "Number of docker containers to run"
   default     = "1"
 }
+
+################## Load Balancer Access Logging Bucket ####################
+
+variable "lb_access_logging_bucket_name" {
+  description = "Load balancer access logging AWS S3 bucket"
+  type        = string
+}

--- a/modules/grafana/load_balancer.tf
+++ b/modules/grafana/load_balancer.tf
@@ -5,6 +5,12 @@ resource "aws_alb" "main_grafana" {
   subnets         = var.public_subnet_ids
   security_groups = [aws_security_group.lb_grafana.id]
 
+  access_logs {
+   bucket  = var.lb_access_logging_bucket_name
+   prefix  = "grafana_access_logs"
+   enabled = true
+  }
+
   tags = var.tags
 }
 

--- a/modules/grafana/load_balancer.tf
+++ b/modules/grafana/load_balancer.tf
@@ -6,9 +6,9 @@ resource "aws_alb" "main_grafana" {
   security_groups = [aws_security_group.lb_grafana.id]
 
   access_logs {
-   bucket  = var.lb_access_logging_bucket_name
-   prefix  = "grafana_access_logs"
-   enabled = true
+    bucket  = var.lb_access_logging_bucket_name
+    prefix  = "grafana_access_logs"
+    enabled = true
   }
 
   tags = var.tags

--- a/modules/grafana/variables.tf
+++ b/modules/grafana/variables.tf
@@ -46,6 +46,13 @@ variable "storage_bucket_arn" {
   type        = string
 }
 
+################## Load Balancer Access Logging Bucket ####################
+
+variable "lb_access_logging_bucket_name" {
+  description = "Load balancer access logging AWS S3 bucket"
+  type        = string
+}
+
 #################### Networking ####################
 variable "public_subnet_ids" {
   type = list

--- a/modules/prometheus/load_balancer.tf
+++ b/modules/prometheus/load_balancer.tf
@@ -6,9 +6,9 @@ resource "aws_alb" "main_prometheus" {
   security_groups = [aws_security_group.lb_prom.id]
 
   access_logs {
-   bucket  = var.lb_access_logging_bucket_name
-   prefix  = "prometheus_access_logs"
-   enabled = true
+    bucket  = var.lb_access_logging_bucket_name
+    prefix  = "prometheus_access_logs"
+    enabled = true
   }
 
   tags = var.tags

--- a/modules/prometheus/load_balancer.tf
+++ b/modules/prometheus/load_balancer.tf
@@ -5,6 +5,12 @@ resource "aws_alb" "main_prometheus" {
   subnets         = var.private_subnet_ids
   security_groups = [aws_security_group.lb_prom.id]
 
+  access_logs {
+   bucket  = var.lb_access_logging_bucket_name
+   prefix  = "prometheus_access_logs"
+   enabled = true
+  }
+
   tags = var.tags
 }
 
@@ -33,3 +39,4 @@ resource "aws_alb_listener" "front_end_prometheus" {
     type             = "forward"
   }
 }
+

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -44,6 +44,13 @@ variable "storage_key_id" {
   type        = string
 }
 
+################## Load Balancer Access Logging Bucket ####################
+
+variable "lb_access_logging_bucket_name" {
+  description = "Load balancer access logging AWS S3 bucket"
+  type        = string
+}
+
 #################### Networking ####################
 variable "public_subnet_ids" {
   type = list

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -72,7 +72,7 @@ resource "aws_kms_key" "this" {
 }
 
 resource "aws_s3_bucket_policy" "this" {
-  count =  var.attach_elb_log_delivery_policy ? 1 : 0
+  count = var.attach_elb_log_delivery_policy ? 1 : 0
 
   bucket = var.encryption_enabled ? aws_s3_bucket.encrypted[0].id : aws_s3_bucket.non-encrypted[0].id
   policy = data.aws_iam_policy_document.elb_log_delivery[0].json

--- a/modules/s3_bucket/main.tf
+++ b/modules/s3_bucket/main.tf
@@ -70,3 +70,38 @@ resource "aws_kms_key" "this" {
   count       = var.encryption_enabled ? 1 : 0
   description = "${var.prefix_pttp}-${var.name} encryption key"
 }
+
+resource "aws_s3_bucket_policy" "this" {
+  count =  var.attach_elb_log_delivery_policy ? 1 : 0
+
+  bucket = var.encryption_enabled ? aws_s3_bucket.encrypted[0].id : aws_s3_bucket.non-encrypted[0].id
+  policy = data.aws_iam_policy_document.elb_log_delivery[0].json
+}
+
+# AWS Load Balancer access log delivery policy
+data "aws_elb_service_account" "this" {
+  count = var.attach_elb_log_delivery_policy ? 1 : 0
+}
+
+data "aws_iam_policy_document" "elb_log_delivery" {
+  count = var.attach_elb_log_delivery_policy ? 1 : 0
+
+  statement {
+    sid = ""
+
+    principals {
+      type        = "AWS"
+      identifiers = data.aws_elb_service_account.this.*.arn
+    }
+
+    effect = "Allow"
+
+    actions = [
+      "s3:PutObject",
+    ]
+
+    resources = [
+      "${var.encryption_enabled ? aws_s3_bucket.encrypted[0].arn : aws_s3_bucket.non-encrypted[0].arn}/*",
+    ]
+  }
+}

--- a/modules/s3_bucket/variables.tf
+++ b/modules/s3_bucket/variables.tf
@@ -38,3 +38,8 @@ variable "versioning_enabled" {
   default = true
   type    = bool
 }
+
+variable "attach_elb_log_delivery_policy" {
+  default = false
+  type    = bool
+}

--- a/modules/s3_bucket/variables.tf
+++ b/modules/s3_bucket/variables.tf
@@ -1,7 +1,7 @@
 variable "acl" {
-  type = string
+  type        = string
   description = "Canned ACL to use"
-  default = "private"
+  default     = "private"
 }
 
 variable "encryption_enabled" {

--- a/modules/snmp_exporter/load_balancer.tf
+++ b/modules/snmp_exporter/load_balancer.tf
@@ -6,9 +6,9 @@ resource "aws_alb" "main_snmp_exporter" {
   security_groups = [aws_security_group.lb_snmp_exporter.id]
 
   access_logs {
-   bucket  = var.lb_access_logging_bucket_name
-   prefix  = "snmp_exporter_access_logs"
-   enabled = true
+    bucket  = var.lb_access_logging_bucket_name
+    prefix  = "snmp_exporter_access_logs"
+    enabled = true
   }
 
   tags = var.tags

--- a/modules/snmp_exporter/load_balancer.tf
+++ b/modules/snmp_exporter/load_balancer.tf
@@ -5,6 +5,12 @@ resource "aws_alb" "main_snmp_exporter" {
   subnets         = var.private_subnet_ids
   security_groups = [aws_security_group.lb_snmp_exporter.id]
 
+  access_logs {
+   bucket  = var.lb_access_logging_bucket_name
+   prefix  = "snmp_exporter_access_logs"
+   enabled = true
+  }
+
   tags = var.tags
 }
 

--- a/modules/snmp_exporter/variables.tf
+++ b/modules/snmp_exporter/variables.tf
@@ -56,3 +56,10 @@ variable "fargate_count" {
   description = "Number of docker containers to run"
   default     = "1"
 }
+
+################## Load Balancer Access Logging Bucket ####################
+
+variable "lb_access_logging_bucket_name" {
+  description = "Load balancer access logging AWS S3 bucket"
+  type        = string
+}

--- a/mojo.tf
+++ b/mojo.tf
@@ -71,10 +71,28 @@ module "grafana_v2" {
 
   storage_bucket_arn = module.grafana-image-storage.bucket_arn
 
+  lb_access_logging_bucket_name = module.grafana_lb_access_logging.bucket_name
+
   providers = {
     aws = aws.env
   }
 }
+
+module "grafana_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "grafana-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
+  providers = {
+    aws = aws.env
+  }
+}
+
 
 module "prometheus_v2" {
   source = "./modules/prometheus"
@@ -100,6 +118,23 @@ module "prometheus_v2" {
   storage_key_arn    = module.prometheus-thanos-storage.kms_key_arn
   storage_key_id     = module.prometheus-thanos-storage.kms_key_id
 
+  lb_access_logging_bucket_name = module.prometheus_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "prometheus_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "prometheus-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
   providers = {
     aws = aws.env
   }
@@ -120,6 +155,23 @@ module "snmp_exporter_v2" {
 
   execution_role_arn = module.monitoring_platform_v2.execution_role_arn
 
+  lb_access_logging_bucket_name = module.snmp_exporter_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "snmp_exporter_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "snmp-exporter-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
+
   providers = {
     aws = aws.env
   }
@@ -139,6 +191,23 @@ module "blackbox_exporter_v2" {
   private_subnet_ids = module.monitoring_platform_v2.private_subnet_ids
 
   execution_role_arn = module.monitoring_platform_v2.execution_role_arn
+
+  lb_access_logging_bucket_name = module.blackbox_exporter_lb_access_logging.bucket_name
+
+  providers = {
+    aws = aws.env
+  }
+}
+
+module "blackbox_exporter_lb_access_logging" {
+  source = "./modules/s3_bucket"
+
+  name               = "blackbox-exporter-lb-access-logging"
+  prefix_pttp        = module.label_pttp.id
+  tags               = module.label_pttp.tags
+  versioning_enabled = false
+  encryption_enabled = false
+  attach_elb_log_delivery_policy = true
 
   providers = {
     aws = aws.env

--- a/mojo.tf
+++ b/mojo.tf
@@ -71,17 +71,17 @@ module "grafana_v2" {
 
   storage_bucket_arn = module.grafana-image-storage.bucket_arn
 
-  lb_access_logging_bucket_name = module.grafana_lb_access_logging.bucket_name
+  lb_access_logging_bucket_name = module.grafana_lb_access_logging_v2.bucket_name
 
   providers = {
     aws = aws.env
   }
 }
 
-module "grafana_lb_access_logging" {
+module "grafana_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "grafana-lb-access-logging"
+  name               = "grafana-lb-access-logging-v2"
   prefix_pttp        = module.label_pttp.id
   tags               = module.label_pttp.tags
   versioning_enabled = false
@@ -92,7 +92,6 @@ module "grafana_lb_access_logging" {
     aws = aws.env
   }
 }
-
 
 module "prometheus_v2" {
   source = "./modules/prometheus"
@@ -118,17 +117,17 @@ module "prometheus_v2" {
   storage_key_arn    = module.prometheus-thanos-storage.kms_key_arn
   storage_key_id     = module.prometheus-thanos-storage.kms_key_id
 
-  lb_access_logging_bucket_name = module.prometheus_lb_access_logging.bucket_name
+  lb_access_logging_bucket_name = module.prometheus_lb_access_logging_v2.bucket_name
 
   providers = {
     aws = aws.env
   }
 }
 
-module "prometheus_lb_access_logging" {
+module "prometheus_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "prometheus-lb-access-logging"
+  name               = "prometheus-lb-access-logging-v2"
   prefix_pttp        = module.label_pttp.id
   tags               = module.label_pttp.tags
   versioning_enabled = false
@@ -155,17 +154,17 @@ module "snmp_exporter_v2" {
 
   execution_role_arn = module.monitoring_platform_v2.execution_role_arn
 
-  lb_access_logging_bucket_name = module.snmp_exporter_lb_access_logging.bucket_name
+  lb_access_logging_bucket_name = module.snmp_exporter_lb_access_logging_v2.bucket_name
 
   providers = {
     aws = aws.env
   }
 }
 
-module "snmp_exporter_lb_access_logging" {
+module "snmp_exporter_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "snmp-exporter-lb-access-logging"
+  name               = "snmp-exporter-lb-access-logging-v2"
   prefix_pttp        = module.label_pttp.id
   tags               = module.label_pttp.tags
   versioning_enabled = false
@@ -192,17 +191,17 @@ module "blackbox_exporter_v2" {
 
   execution_role_arn = module.monitoring_platform_v2.execution_role_arn
 
-  lb_access_logging_bucket_name = module.blackbox_exporter_lb_access_logging.bucket_name
+  lb_access_logging_bucket_name = module.blackbox_exporter_lb_access_logging_v2.bucket_name
 
   providers = {
     aws = aws.env
   }
 }
 
-module "blackbox_exporter_lb_access_logging" {
+module "blackbox_exporter_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "blackbox-exporter-lb-access-logging"
+  name               = "blackbox-exporter-lb-access-logging-v2"
   prefix_pttp        = module.label_pttp.id
   tags               = module.label_pttp.tags
   versioning_enabled = false

--- a/mojo.tf
+++ b/mojo.tf
@@ -81,11 +81,11 @@ module "grafana_v2" {
 module "grafana_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "grafana-lb-access-logging-v2"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "grafana-lb-access-logging-v2"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -127,11 +127,11 @@ module "prometheus_v2" {
 module "prometheus_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "prometheus-lb-access-logging-v2"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "prometheus-lb-access-logging-v2"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -164,11 +164,11 @@ module "snmp_exporter_v2" {
 module "snmp_exporter_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "snmp-exporter-lb-access-logging-v2"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "snmp-exporter-lb-access-logging-v2"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {
@@ -201,11 +201,11 @@ module "blackbox_exporter_v2" {
 module "blackbox_exporter_lb_access_logging_v2" {
   source = "./modules/s3_bucket"
 
-  name               = "blackbox-exporter-lb-access-logging-v2"
-  prefix_pttp        = module.label_pttp.id
-  tags               = module.label_pttp.tags
-  versioning_enabled = false
-  encryption_enabled = false
+  name                           = "blackbox-exporter-lb-access-logging-v2"
+  prefix_pttp                    = module.label_pttp.id
+  tags                           = module.label_pttp.tags
+  versioning_enabled             = false
+  encryption_enabled             = false
   attach_elb_log_delivery_policy = true
 
   providers = {


### PR DESCRIPTION
This change enables ELB_v2 access logging on the load balancers to an AWS S3 bucket for Grafana, Prometheus, Blackbox_Exporter and SNMP_Exporter as per pen test recommendations. 

Jira - [PTTP-3589](https://dsdmoj.atlassian.net/browse/PTTP-3589)