### PR TITLE
deploys Azure metrics exporter container in EKS cluster

### DIFF
--- a/kubernetes/prometheus-thanos/templates/azure-metrics-exporter-service.yaml
+++ b/kubernetes/prometheus-thanos/templates/azure-metrics-exporter-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-azure-metrics-exporter
+spec:
+  selector:
+    app: azure-metrics-exporter
+  ports:
+    - name: http
+      protocol: TCP
+      port: 9276
+      targetPort: 9276
+  

--- a/kubernetes/prometheus-thanos/templates/azure-metrics-exporter.yaml
+++ b/kubernetes/prometheus-thanos/templates/azure-metrics-exporter.yaml
@@ -1,0 +1,35 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-azure-metrics-exporter
+  labels:
+    app: azure-metrics-exporter
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: azure-metrics-exporter
+  template:
+    metadata:
+      labels:
+        app: azure-metrics-exporter
+    spec:
+      containers:
+      - name: azure-metrics-exporter
+        image: robustperception/azure_metrics_exporter:latest
+        command: ["azure_metrics_exporter"]
+        args: 
+          - "--config.file=/config/azure.yml"
+        ports:
+        - containerPort: 9276
+        volumeMounts:
+        - name: configuration
+          mountPath: "/config"
+          readOnly: true
+      volumes:
+      - name: configuration
+        configMap:
+          name: azure-metrics-exporter-configmap
+          items:
+          - key: "azure.yml"
+            path: "azure.yml"


### PR DESCRIPTION
also creates a service for the pod containing azure metrics exporter
this deployment depends on the configmaps that are created by:
https://github.com/ministryofjustice/staff-infrastructure-metric-aggregation-server/tree/spike-pushing-config-maps