### PR TITLE
Pttp 3736/cloudwatch exporter

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -36,7 +36,7 @@ env:
     TF_VAR_grafana_image_repository_url: "/codebuild/pttp-ci-ima-pipeline/grafana_image_repository_url"
     TF_VAR_grafana_image_renderer_repository_url: "/codebuild/pttp-ci-ima-pipeline/grafana_image_renderer_repository_url"
     TF_VAR_thanos_image_repository_url: "/codebuild/pttp-ci-ima-pipeline/thanos_image_repository_url"
-    
+    TF_VAR_cloudwatch_exporter_access_role_arns: "/codebuild/pttp-ci-ima-pipeline/$ENV/cloudwatch_exporter_access_role_arns"
 phases:
   install:
     on-failure: CONTINUE

--- a/modules/blackbox_exporter/variables.tf
+++ b/modules/blackbox_exporter/variables.tf
@@ -25,11 +25,11 @@ variable "cluster_id" {
 
 #################### Networking ####################
 variable "public_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 variable "private_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 #################### Fargate ####################

--- a/modules/cloudwatch_exporter/iam.tf
+++ b/modules/cloudwatch_exporter/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cloudwatch_exporter_assume_role" {
-  name = "${var.prefix}-cloudwatch-exporter-production-assume-role"
+  name        = "${var.prefix}-cloudwatch-exporter-production-assume-role"
   description = "Allows the production root account access to Cloudwatch metrics for the current environment"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",

--- a/modules/cloudwatch_exporter/iam.tf
+++ b/modules/cloudwatch_exporter/iam.tf
@@ -1,5 +1,5 @@
 resource "aws_iam_role" "cloudwatch_exporter_assume_role" {
-  name = "cloudwatch_exporter_production_assume_role"
+  name = "${var.prefix}-cloudwatch-exporter-production-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/cloudwatch_exporter/iam.tf
+++ b/modules/cloudwatch_exporter/iam.tf
@@ -1,4 +1,5 @@
 resource "aws_iam_role" "cloudwatch_exporter_assume_role" {
+  # If renaming this role, the name reference for the data sources in monitoring_platform/eks_policies.tf need to be updated
   name = "${var.prefix}-cloudwatch-exporter-production-assume-role"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",

--- a/modules/cloudwatch_exporter/iam.tf
+++ b/modules/cloudwatch_exporter/iam.tf
@@ -1,0 +1,17 @@
+resource "aws_iam_role" "cloudwatch_exporter_assume_role" {
+  name = "cloudwatch_exporter_production_assume_role"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Action    = "sts:AssumeRole",
+        Principal = { "AWS" : "arn:aws:iam::${var.production_account_id}:root" }
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "production_cloudwatch_access_policy_attachment" {
+  policy_arn = var.cloudwatch_access_policy_arn
+  role       = aws_iam_role.cloudwatch_exporter_assume_role.name
+}

--- a/modules/cloudwatch_exporter/iam.tf
+++ b/modules/cloudwatch_exporter/iam.tf
@@ -1,6 +1,6 @@
 resource "aws_iam_role" "cloudwatch_exporter_assume_role" {
-  # If renaming this role, the name reference for the data sources in monitoring_platform/eks_policies.tf need to be updated
   name = "${var.prefix}-cloudwatch-exporter-production-assume-role"
+  description = "Allows the production root account access to Cloudwatch metrics for the current environment"
   assume_role_policy = jsonencode({
     Version = "2012-10-17",
     Statement = [

--- a/modules/cloudwatch_exporter/outputs.tf
+++ b/modules/cloudwatch_exporter/outputs.tf
@@ -1,0 +1,3 @@
+output "assume_role_arn" {
+  value = aws_iam_role.cloudwatch_exporter_assume_role.arn
+}

--- a/modules/cloudwatch_exporter/policies/cloudwatch_access_policy.template.json
+++ b/modules/cloudwatch_exporter/policies/cloudwatch_access_policy.template.json
@@ -1,0 +1,18 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:GetMetricData",
+                "cloudwatch:ListMetrics",
+                "tag:GetResources"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/modules/cloudwatch_exporter/variables.tf
+++ b/modules/cloudwatch_exporter/variables.tf
@@ -1,0 +1,7 @@
+variable "production_account_id" {
+  type = string
+}
+
+variable "cloudwatch_access_policy_arn" {
+  type = string
+}

--- a/modules/cloudwatch_exporter/variables.tf
+++ b/modules/cloudwatch_exporter/variables.tf
@@ -5,3 +5,7 @@ variable "production_account_id" {
 variable "cloudwatch_access_policy_arn" {
   type = string
 }
+
+variable "prefix" {
+  type = string
+}

--- a/modules/grafana/variables.tf
+++ b/modules/grafana/variables.tf
@@ -55,11 +55,11 @@ variable "lb_access_logging_bucket_name" {
 
 #################### Networking ####################
 variable "public_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 variable "private_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 #################### Fargate ####################
@@ -169,6 +169,6 @@ variable "azure_ad_token_url" {
 }
 
 variable "sns_subscribers" {
-  type    = list
+  type    = list(any)
   default = []
 }

--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -20,31 +20,3 @@ module "monitoring_alerting_cluster" {
     },
   ]
 }
-
-resource "aws_iam_policy" "s3_access_policy" {
-  name = "${var.prefix}-thanos-worker-policy"
-
-  policy = templatefile("${path.module}/policies/s3_access_policy.template.json", {
-    bucket = var.storage_bucket_name
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {
-  policy_arn = aws_iam_policy.s3_access_policy.arn
-  role       = module.monitoring_alerting_cluster.worker_iam_role_name
-  count      = var.is_eks_enabled ? 1 : 0
-}
-
-resource "aws_iam_policy" "kms_access_policy" {
-  name = "${var.prefix}-thanos-prometheus-kms-policy"
-
-  policy = templatefile("${path.module}/policies/kms_access_policy.template.json", {
-    kms_key_arn = var.storage_key_arn
-  })
-}
-
-resource "aws_iam_role_policy_attachment" "kms_access_policy_attachment" {
-  policy_arn = aws_iam_policy.kms_access_policy.arn
-  role       = module.monitoring_alerting_cluster.worker_iam_role_name
-  count      = var.is_eks_enabled ? 1 : 0
-}

--- a/modules/monitoring_platform/eks_policies.tf
+++ b/modules/monitoring_platform/eks_policies.tf
@@ -1,4 +1,6 @@
-
+locals {
+  any_cloudwatch_exporter_roles = length(var.cloudwatch_exporter_access_role_arns) > 0
+}
 resource "aws_iam_policy" "s3_access_policy" {
   name = "${var.prefix}-thanos-worker-policy"
 
@@ -39,42 +41,16 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_access_eks_policy_attachme
   count      = var.is_eks_enabled ? 1 : 0
 }
 
-data "aws_iam_role" "production_role" {
-  count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name  = "mojo-production-ima-cloudwatch-exporter-production-assume-role"
-}
-
-data "aws_iam_role" "pre_production_role" {
-  count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name  = "mojo-pre-production-ima-cloudwatch-exporter-production-assume-role"
-}
-
-data "aws_iam_role" "development_role" {
-  count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name  = "mojo-development-ima-cloudwatch-exporter-production-assume-role"
-}
-
 resource "aws_iam_role_policy" "assume_cross_account_roles" {
-  count  = var.is_production && var.is_eks_enabled ? 1 : 0
+  count = local.any_cloudwatch_exporter_roles && var.is_eks_enabled ? 1 : 0
   role   = module.monitoring_alerting_cluster.worker_iam_role_name
   policy = element(data.aws_iam_policy_document.assume_cross_account_roles.*.json, 0)
 }
 
 data "aws_iam_policy_document" "assume_cross_account_roles" {
-  count = var.is_production && var.is_eks_enabled ? 1 : 0
-
+  count = local.any_cloudwatch_exporter_roles && var.is_eks_enabled ? 1 : 0
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.production_role[0].arn]
-  }
-
-  statement {
-    actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.pre_production_role[0].arn]
-  }
-
-  statement {
-    actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.development_role[0].arn]
+    resources = var.cloudwatch_exporter_access_role_arns
   }
 }

--- a/modules/monitoring_platform/eks_policies.tf
+++ b/modules/monitoring_platform/eks_policies.tf
@@ -42,7 +42,7 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_access_eks_policy_attachme
 }
 
 resource "aws_iam_role_policy" "assume_cross_account_roles" {
-  count = local.any_cloudwatch_exporter_roles && var.is_eks_enabled ? 1 : 0
+  count  = local.any_cloudwatch_exporter_roles && var.is_eks_enabled ? 1 : 0
   role   = module.monitoring_alerting_cluster.worker_iam_role_name
   policy = element(data.aws_iam_policy_document.assume_cross_account_roles.*.json, 0)
 }

--- a/modules/monitoring_platform/eks_policies.tf
+++ b/modules/monitoring_platform/eks_policies.tf
@@ -1,0 +1,40 @@
+
+resource "aws_iam_policy" "s3_access_policy" {
+  name = "${var.prefix}-thanos-worker-policy"
+
+  policy = templatefile("${path.module}/policies/s3_access_policy.template.json", {
+    bucket = var.storage_bucket_arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "s3_access_policy_attachment" {
+  policy_arn = aws_iam_policy.s3_access_policy.arn
+  role       = module.monitoring_alerting_cluster.worker_iam_role_name
+  count      = var.is_eks_enabled ? 1 : 0
+}
+
+resource "aws_iam_policy" "kms_access_policy" {
+  name = "${var.prefix}-thanos-prometheus-kms-policy"
+
+  policy = templatefile("${path.module}/policies/kms_access_policy.template.json", {
+    kms_key_arn = var.storage_key_arn
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "kms_access_policy_attachment" {
+  policy_arn = aws_iam_policy.kms_access_policy.arn
+  role       = module.monitoring_alerting_cluster.worker_iam_role_name
+  count      = var.is_eks_enabled ? 1 : 0
+}
+
+resource "aws_iam_policy" "cloudwatch_access_eks_policy" {
+  name = "${var.prefix}-cloudwatch-access-eks-policy"
+
+  policy = templatefile("${path.module}/policies/cloudwatch_access_policy.template.json", {})
+}
+
+resource "aws_iam_role_policy_attachment" "cloudwatch_access_eks_policy_attachment" {
+  policy_arn = aws_iam_policy.cloudwatch_access_eks_policy.arn
+  role       = module.monitoring_alerting_cluster.worker_iam_role_name
+  count      = var.is_eks_enabled ? 1 : 0
+}

--- a/modules/monitoring_platform/eks_policies.tf
+++ b/modules/monitoring_platform/eks_policies.tf
@@ -41,17 +41,17 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_access_eks_policy_attachme
 
 data "aws_iam_role" "production_role" {
   count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name = "mojo-production-ima-cloudwatch-exporter-production-assume-role"
+  name  = "mojo-production-ima-cloudwatch-exporter-production-assume-role"
 }
 
 data "aws_iam_role" "pre_production_role" {
   count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name = "mojo-pre-production-ima-cloudwatch-exporter-production-assume-role"
+  name  = "mojo-pre-production-ima-cloudwatch-exporter-production-assume-role"
 }
 
 data "aws_iam_role" "development_role" {
   count = var.is_production && var.is_eks_enabled ? 1 : 0
-  name = "mojo-development-ima-cloudwatch-exporter-production-assume-role"
+  name  = "mojo-development-ima-cloudwatch-exporter-production-assume-role"
 }
 
 resource "aws_iam_role_policy" "assume_cross_account_roles" {

--- a/modules/monitoring_platform/eks_policies.tf
+++ b/modules/monitoring_platform/eks_policies.tf
@@ -40,14 +40,17 @@ resource "aws_iam_role_policy_attachment" "cloudwatch_access_eks_policy_attachme
 }
 
 data "aws_iam_role" "production_role" {
+  count = var.is_production && var.is_eks_enabled ? 1 : 0
   name = "mojo-production-ima-cloudwatch-exporter-production-assume-role"
 }
 
 data "aws_iam_role" "pre_production_role" {
+  count = var.is_production && var.is_eks_enabled ? 1 : 0
   name = "mojo-pre-production-ima-cloudwatch-exporter-production-assume-role"
 }
 
 data "aws_iam_role" "development_role" {
+  count = var.is_production && var.is_eks_enabled ? 1 : 0
   name = "mojo-development-ima-cloudwatch-exporter-production-assume-role"
 }
 
@@ -62,16 +65,16 @@ data "aws_iam_policy_document" "assume_cross_account_roles" {
 
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.production_role.arn]
+    resources = [data.aws_iam_role.production_role[0].arn]
   }
 
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.pre_production_role.arn]
+    resources = [data.aws_iam_role.pre_production_role[0].arn]
   }
 
   statement {
     actions   = ["sts:AssumeRole"]
-    resources = [data.aws_iam_role.development_role.arn]
+    resources = [data.aws_iam_role.development_role[0].arn]
   }
 }

--- a/modules/monitoring_platform/outputs.tf
+++ b/modules/monitoring_platform/outputs.tf
@@ -37,3 +37,7 @@ output "eks_cluster_endpoint" {
 output "eks_cluster_worker_iam_role_arn" {
   value = module.monitoring_alerting_cluster.worker_iam_role_arn
 }
+
+output "cloudwatch_access_policy" {
+  value = aws_iam_policy.cloudwatch_access_eks_policy.arn
+}

--- a/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
+++ b/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
@@ -1,0 +1,16 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Statement",
+            "Effect": "Allow",
+            "Action": [
+                "cloudwatch:GetMetricStatistics",
+                "cloudwatch:ListMetrics"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}

--- a/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
+++ b/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
@@ -6,7 +6,9 @@
             "Effect": "Allow",
             "Action": [
                 "cloudwatch:GetMetricStatistics",
-                "cloudwatch:ListMetrics"
+                "cloudwatch:GetMetricData",
+                "cloudwatch:ListMetrics",
+                "tag:GetResources"
             ],
             "Resource": [
                 "*"

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -61,6 +61,13 @@ variable "storage_key_arn" {
   type        = string
 }
 
+
 variable "vpc_flow_log_bucket_arn" {
   type    = string
+}
+
+variable "cloudwatch_exporter_access_role_arns" {
+  description = "Cloudwatch exporter role arns for access to metric data"
+  type = set(string)
+  default = []
 }

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -63,11 +63,11 @@ variable "storage_key_arn" {
 
 
 variable "vpc_flow_log_bucket_arn" {
-  type    = string
+  type = string
 }
 
 variable "cloudwatch_exporter_access_role_arns" {
   description = "Cloudwatch exporter role arns for access to metric data"
-  type = set(string)
-  default = []
+  type        = set(string)
+  default     = []
 }

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -11,6 +11,11 @@ variable "tags" {
   type = map(string)
 }
 
+variable "is_production" {
+  type    = bool
+  default = false
+}
+
 variable "enable_transit_gateway" {
   type    = bool
   default = false
@@ -42,6 +47,11 @@ variable "is_eks_enabled" {
 }
 
 variable "storage_bucket_name" {
+  type    = string
+  default = ""
+}
+
+variable "storage_bucket_arn" {
   type    = string
   default = ""
 }

--- a/modules/prometheus/variables.tf
+++ b/modules/prometheus/variables.tf
@@ -53,11 +53,11 @@ variable "lb_access_logging_bucket_name" {
 
 #################### Networking ####################
 variable "public_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 variable "private_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 #################### Fargate ####################

--- a/modules/snmp_exporter/variables.tf
+++ b/modules/snmp_exporter/variables.tf
@@ -25,11 +25,11 @@ variable "cluster_id" {
 
 #################### Networking ####################
 variable "public_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 variable "private_subnet_ids" {
-  type = list
+  type = list(any)
 }
 
 #################### Fargate ####################

--- a/mojo.tf
+++ b/mojo.tf
@@ -236,6 +236,7 @@ module "test_bastion" {
 module "cloudwatch_exporter" {
   source                       = "./modules/cloudwatch_exporter"
   production_account_id        = var.production_account_id
+  prefix                       = module.label_mojo.id
   cloudwatch_access_policy_arn = module.monitoring_platform_v2.cloudwatch_access_policy
 
   providers = {

--- a/mojo.tf
+++ b/mojo.tf
@@ -28,6 +28,8 @@ module "monitoring_platform_v2" {
 
   vpc_flow_log_bucket_arn    = module.vpc_flow_logging.bucket_arn
 
+  cloudwatch_exporter_access_role_arns = split(",", var.cloudwatch_exporter_access_role_arns)
+
   providers = {
     aws = aws.env
   }

--- a/mojo.tf
+++ b/mojo.tf
@@ -19,9 +19,13 @@ module "monitoring_platform_v2" {
   private_subnet_cidr_blocks = [for cidr_block in cidrsubnets("10.180.100.0/22", 2, 2, 2) : cidrsubnets(cidr_block, 1, 1)[0]]
   public_subnet_cidr_blocks  = [for cidr_block in cidrsubnets("10.180.100.0/22", 2, 2, 2) : cidrsubnets(cidr_block, 1, 1)[1]]
 
-  is_eks_enabled      = true
+  is_eks_enabled = true
+  is_production  = var.is-production == "true"
+
+  storage_bucket_arn = module.prometheus-thanos-storage.bucket_arn
   storage_bucket_name = module.prometheus-thanos-storage.bucket_name
-  storage_key_arn     = module.prometheus-thanos-storage.kms_key_arn
+  storage_key_arn    = module.prometheus-thanos-storage.kms_key_arn
+
   vpc_flow_log_bucket_arn    = module.vpc_flow_logging.bucket_arn
 
   providers = {

--- a/mojo.tf
+++ b/mojo.tf
@@ -234,8 +234,8 @@ module "test_bastion" {
 }
 
 module "cloudwatch_exporter" {
-  source                = "./modules/cloudwatch_exporter"
-  production_account_id = var.production_account_id
+  source                       = "./modules/cloudwatch_exporter"
+  production_account_id        = var.production_account_id
   cloudwatch_access_policy_arn = module.monitoring_platform_v2.cloudwatch_access_policy
 
   providers = {

--- a/mojo.tf
+++ b/mojo.tf
@@ -22,11 +22,11 @@ module "monitoring_platform_v2" {
   is_eks_enabled = true
   is_production  = var.is-production == "true"
 
-  storage_bucket_arn = module.prometheus-thanos-storage.bucket_arn
+  storage_bucket_arn  = module.prometheus-thanos-storage.bucket_arn
   storage_bucket_name = module.prometheus-thanos-storage.bucket_name
-  storage_key_arn    = module.prometheus-thanos-storage.kms_key_arn
+  storage_key_arn     = module.prometheus-thanos-storage.kms_key_arn
 
-  vpc_flow_log_bucket_arn    = module.vpc_flow_logging.bucket_arn
+  vpc_flow_log_bucket_arn = module.vpc_flow_logging.bucket_arn
 
   cloudwatch_exporter_access_role_arns = split(",", var.cloudwatch_exporter_access_role_arns)
 

--- a/mojo.tf
+++ b/mojo.tf
@@ -214,6 +214,7 @@ module "blackbox_exporter_lb_access_logging_v2" {
   }
 }
 
+
 module "test_bastion" {
   source                     = "./modules/test_bastion"
   subnets                    = module.monitoring_platform_v2.public_subnet_ids
@@ -230,4 +231,14 @@ module "test_bastion" {
   }
 
   count = var.enable_test_bastion == true ? 1 : 0
+}
+
+module "cloudwatch_exporter" {
+  source                = "./modules/cloudwatch_exporter"
+  production_account_id = var.production_account_id
+  cloudwatch_access_policy_arn = module.monitoring_platform_v2.cloudwatch_access_policy
+
+  providers = {
+    aws = aws.env
+  }
 }

--- a/mojo_outputs.tf
+++ b/mojo_outputs.tf
@@ -73,3 +73,7 @@ output "prometheus_thanos_storage_kms_key_id" {
 output "cloudwatch_exporter_assume_role_arn" {
   value = module.cloudwatch_exporter.assume_role_arn
 }
+
+output "cloudwatch_exporter_access_role_arns" {
+  value = var.cloudwatch_exporter_access_role_arns
+}

--- a/mojo_outputs.tf
+++ b/mojo_outputs.tf
@@ -69,3 +69,7 @@ output "prometheus_thanos_storage_bucket_name" {
 output "prometheus_thanos_storage_kms_key_id" {
   value = module.prometheus-thanos-storage.kms_key_id
 }
+
+output "cloudwatch_exporter_assume_role_arn" {
+  value = module.cloudwatch_exporter.assume_role_arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -133,6 +133,6 @@ variable "bastion_allowed_ingress_ip" {
 
 variable "cloudwatch_exporter_access_role_arns" {
   description = "Cloudwatch exporter role arns for access to metric data"
-  type = string
-  default = ""
+  type        = string
+  default     = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -13,6 +13,10 @@ variable "is-production" {
   default = "true"
 }
 
+variable "production_account_id" {
+  type = string
+}
+
 variable "assume_role" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -130,3 +130,9 @@ variable "bastion_allowed_ingress_ip" {
   type    = string
   default = "0.0.0.0"
 }
+
+variable "cloudwatch_exporter_access_role_arns" {
+  description = "Cloudwatch exporter role arns for access to metric data"
+  type = string
+  default = ""
+}


### PR DESCRIPTION
This adds an alertmanager instance to the EKS cluster with a few initial metrics, with metrics being retrieved for their respective accounts for dev and pre-production but in production retrieving metrics from dev, pre-production and production.

- Adds a policy to give access to cloudwatch for the worker nodes, I refactored all the policies into a separate file whilst doing this. 
- Creates roles for production account to assume that allow it to get metrics in the other accounts

We will flesh out the production config file for the exporter in a later PR.