### PR TITLE
Corrects prefix name for BB S3 bucket

### DIFF
--- a/modules/blackbox_exporter/load_balancer.tf
+++ b/modules/blackbox_exporter/load_balancer.tf
@@ -7,7 +7,7 @@ resource "aws_alb" "main_blackbox_exporter" {
 
   access_logs {
     bucket  = var.lb_access_logging_bucket_name
-    prefix  = "grafana_access_logs"
+    prefix  = "blackbox_exporter_access_logs"
     enabled = true
   }
 


### PR DESCRIPTION
corrects the prefix name in the AWS S3 bucket for the blackbox_exporter load balancer access logs. 