### PR TITLE
adds `AWS SES Email From` in `Terraform outputs`

### DIFF
--- a/modules/grafana/outputs.tf
+++ b/modules/grafana/outputs.tf
@@ -13,3 +13,7 @@ output "grafana_db_subnet_group_name" {
 output "db_in_security_group_id" {
   value = aws_security_group.db_in.id
 }
+
+output "ses_mail_from_domain" {
+  value = aws_ses_domain_mail_from.grafana_email_from.mail_from_domain
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -87,3 +87,7 @@ output "cloudwatch_exporter_assume_role_arn" {
 output "cloudwatch_exporter_access_role_arns" {
   value = var.cloudwatch_exporter_access_role_arns
 }
+
+output "ses_mail_from_domain" {
+  value = module.grafana_v2.ses_mail_from_domain
+}


### PR DESCRIPTION
Prometheus alertmanager configmap will use this `SES email from` to
configure the alerts to send email notifications.