### PR TITLE
Fixing problem with S3 bucket ARN address.

### DIFF
--- a/modules/monitoring_platform/policies/s3_access_policy.template.json
+++ b/modules/monitoring_platform/policies/s3_access_policy.template.json
@@ -11,8 +11,8 @@
                 "s3:PutObject"
             ],
             "Resource": [
-                "arn:aws:s3:::${bucket}/*",
-                "arn:aws:s3:::${bucket}"
+                "${bucket}/*",
+                "${bucket}"
             ]
         }
     ]


### PR DESCRIPTION
This was adding "arn:aws:s3:::" as a prefix to the bucket name when this was already being included as part of the bucket name.