### PR TITLE
Give cloudwatch exporter permission to discover api gateway resources

### DIFF
--- a/modules/cloudwatch_exporter/policies/cloudwatch_access_policy.template.json
+++ b/modules/cloudwatch_exporter/policies/cloudwatch_access_policy.template.json
@@ -8,7 +8,8 @@
                 "cloudwatch:GetMetricStatistics",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListMetrics",
-                "tag:GetResources"
+                "tag:GetResources",
+                "apigateway:GET"
             ],
             "Resource": [
                 "*"

--- a/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
+++ b/modules/monitoring_platform/policies/cloudwatch_access_policy.template.json
@@ -8,7 +8,8 @@
                 "cloudwatch:GetMetricStatistics",
                 "cloudwatch:GetMetricData",
                 "cloudwatch:ListMetrics",
-                "tag:GetResources"
+                "tag:GetResources",
+                "apigateway:GET"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
As per the [yace docs](https://github.com/ivx/yet-another-cloudwatch-exporter/blob/master/README.md#iam) cloudwatch exporter needs this permission to discover API gateway resources.