### PR TITLE
Create an outbound Route53 endpoint

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -40,6 +40,7 @@ env:
     TF_VAR_cloudwatch_exporter_access_role_arns: "/codebuild/pttp-ci-ima-pipeline/$ENV/cloudwatch_exporter_access_role_arns"
     TF_VAR_production_account_id: "/codebuild/pttp-ci-ima-pipeline/production_account_id"
     TF_VAR_enable_test_bastion: "/codebuild/pttp-ci-ima-pipeline/$ENV/enable_test_bastion"
+    TF_VAR_enable_ima_dns_resolver: "/codebuild/pttp-ci-ima-pipeline/$ENV/enable_ima_dns_resolver"
     TF_VAR_gsi_domain: "/codebuild/pttp-ci-ima-pipeline/$ENV/gsi_domain"
     TF_VAR_mojo_dns_ip_1: "/codebuild/pttp-ci-ima-pipeline/$ENV/mojo_dns_ip_1"
     TF_VAR_mojo_dns_ip_2: "/codebuild/pttp-ci-ima-pipeline/$ENV/mojo_dns_ip_2"

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -40,6 +40,9 @@ env:
     TF_VAR_cloudwatch_exporter_access_role_arns: "/codebuild/pttp-ci-ima-pipeline/$ENV/cloudwatch_exporter_access_role_arns"
     TF_VAR_production_account_id: "/codebuild/pttp-ci-ima-pipeline/production_account_id"
     TF_VAR_enable_test_bastion: "/codebuild/pttp-ci-ima-pipeline/$ENV/enable_test_bastion"
+    TF_VAR_gsi_domain: "/codebuild/pttp-ci-ima-pipeline/$ENV/gsi_domain"
+    TF_VAR_mojo_dns_ip_1: "/codebuild/pttp-ci-ima-pipeline/$ENV/mojo_dns_ip_1"
+    TF_VAR_mojo_dns_ip_2: "/codebuild/pttp-ci-ima-pipeline/$ENV/mojo_dns_ip_2"
 phases:
   install:
     on-failure: CONTINUE

--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,11 @@ module "monitoring_platform_v2" {
 
   cloudwatch_exporter_access_role_arns = compact(split(",", trimspace(var.cloudwatch_exporter_access_role_arns)))
 
+  enable_ima_dns_resolver = var.is-production
+  gsi_domain              = var.gsi_domain
+  mojo_dns_ip_1           = var.mojo_dns_ip_1
+  mojo_dns_ip_2           = var.mojo_dns_ip_2
+
   providers = {
     aws = aws.env
   }

--- a/main.tf
+++ b/main.tf
@@ -84,7 +84,7 @@ module "monitoring_platform_v2" {
 
   cloudwatch_exporter_access_role_arns = compact(split(",", trimspace(var.cloudwatch_exporter_access_role_arns)))
 
-  enable_ima_dns_resolver = var.is-production
+  enable_ima_dns_resolver = var.enable_ima_dns_resolver
   gsi_domain              = var.gsi_domain
   mojo_dns_ip_1           = var.mojo_dns_ip_1
   mojo_dns_ip_2           = var.mojo_dns_ip_2

--- a/modules/monitoring_platform/network.tf
+++ b/modules/monitoring_platform/network.tf
@@ -79,6 +79,16 @@ resource "aws_route_table" "private" {
     nat_gateway_id = element(aws_nat_gateway.gw.*.id, count.index)
   }
 
+  route {
+    cidr_block         = "${var.mojo_dns_ip_1}/32"
+    transit_gateway_id = var.transit_gateway_id
+  }
+
+  route {
+    cidr_block         = "${var.mojo_dns_ip_2}/32"
+    transit_gateway_id = var.transit_gateway_id
+  }
+
   tags = var.tags
 }
 

--- a/modules/monitoring_platform/route53_resolver.tf
+++ b/modules/monitoring_platform/route53_resolver.tf
@@ -1,0 +1,58 @@
+resource "aws_route53_resolver_endpoint" "ima_vpc_outbound" {
+  count = var.enable_ima_dns_resolver ? 1 : 0
+
+  name      = "ima-resolver-${var.prefix}"
+  direction = "OUTBOUND"
+
+  security_group_ids = [
+    aws_security_group.route53_resolver.id
+  ]
+
+  ip_address {
+    subnet_id = aws_subnet.private[0]
+  }
+
+  ip_address {
+    subnet_id = aws_subnet.private[1]
+  }
+
+  ip_address {
+    subnet_id = aws_subnet.private[2]
+  }
+}
+
+resource "aws_route53_resolver_rule" "mojo_dns_rule" {
+  count = var.enable_ima_dns_resolver ? 1 : 0
+
+  name                 = "ima-mojo-resolver-rule-${var.prefix}"
+  rule_type            = "FORWARD"
+  domain_name          = var.gsi_domain
+  resolver_endpoint_id = aws_route53_resolver_endpoint.ima_vpc_outbound.*.id[0]
+
+  target_ip {
+    ip   = var.mojo_dns_ip_1
+    port = "53"
+  }
+
+  target_ip {
+    ip   = var.mojo_dns_ip_2
+    port = "53"
+  }
+}
+
+resource "aws_route53_resolver_rule_association" "ima_mojo_rule_association" {
+  count = var.enable_ima_dns_resolver ? 1 : 0
+
+  resolver_rule_id = aws_route53_resolver_rule.mojo_dns_rule.*.id[0]
+  vpc_id           = aws_vpc.main.id
+}
+
+resource "aws_route53_resolver_query_log_config" "ima_mojo_resolver_query_log" {
+  name            = "ima-resolver-query-log-${var.prefix}"
+  destination_arn = aws_cloudwatch_log_group.vpc_flow_log_group.id
+}
+
+resource "aws_route53_resolver_query_log_config_association" "ima_resolver_query_log_association" {
+  resolver_query_log_config_id = aws_route53_resolver_query_log_config.ima_mojo_resolver_query_log.id
+  resource_id                  = aws_vpc.main.id
+}

--- a/modules/monitoring_platform/security_group.tf
+++ b/modules/monitoring_platform/security_group.tf
@@ -1,0 +1,25 @@
+resource "aws_security_group" "route53_resolver" {
+  name        = "${var.prefix}-route53-resolver"
+  description = "Allow ingress and egress traffic for route53 resolver"
+  vpc_id      = aws_vpc.main.id
+}
+
+resource "aws_security_group_rule" "dns_1_out" {
+  description       = "Allow DNS lookups against the MoJO DNS servers in eu-west-2a"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.route53_resolver.id
+  cidr_blocks       = ["${var.mojo_dns_ip_1}/32"]
+}
+
+resource "aws_security_group_rule" "dns_2_out" {
+  description       = "Allow DNS lookups against the MoJO DNS servers in eu-west-2b"
+  type              = "egress"
+  from_port         = 53
+  to_port           = 53
+  protocol          = "udp"
+  security_group_id = aws_security_group.route53_resolver.id
+  cidr_blocks       = ["${var.mojo_dns_ip_2}/32"]
+}

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -78,7 +78,6 @@ variable "cloudwatch_exporter_access_role_arns" {
 
 variable "enable_ima_dns_resolver" {
   type    = bool
-  default = false
 }
 
 variable "gsi_domain" {

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -75,3 +75,20 @@ variable "cloudwatch_exporter_access_role_arns" {
   type        = set(string)
   default     = []
 }
+
+variable "enable_ima_dns_resolver" {
+  type    = bool
+  default = false
+}
+
+variable "gsi_domain" {
+  type = string
+}
+
+variable "mojo_dns_ip_1" {
+  type = string
+}
+
+variable "mojo_dns_ip_2" {
+  type = string
+}

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -77,7 +77,7 @@ variable "cloudwatch_exporter_access_role_arns" {
 }
 
 variable "enable_ima_dns_resolver" {
-  type    = bool
+  type = bool
 }
 
 variable "gsi_domain" {

--- a/variables.tf
+++ b/variables.tf
@@ -136,3 +136,17 @@ variable "cloudwatch_exporter_access_role_arns" {
   type        = string
   default     = ""
 }
+
+#################### Route53 details ####################
+
+variable "gsi_domain" {
+  type = string
+}
+
+variable "mojo_dns_ip_1" {
+  type = string
+}
+
+variable "mojo_dns_ip_2" {
+  type = string
+}

--- a/variables.tf
+++ b/variables.tf
@@ -139,6 +139,11 @@ variable "cloudwatch_exporter_access_role_arns" {
 
 #################### Route53 details ####################
 
+variable "enable_ima_dns_resolver" {
+  type    = bool
+  default = false
+}
+
 variable "gsi_domain" {
   type = string
 }


### PR DESCRIPTION
and create mojo dns route 53 rules to forward dns queries to mojo dns for gsi domain.
this feature is only enabled in production environment.
a flag is used to filter non production environments.