### PR TITLE
Removing specified version number for ECS

### DIFF
--- a/modules/grafana/service.tf
+++ b/modules/grafana/service.tf
@@ -92,7 +92,6 @@ resource "aws_ecs_task_definition" "grafana_task_definition" {
 resource "aws_ecs_service" "grafana_ecs_service" {
   name = "${var.prefix_pttp}-grafana-ecs-service"
 
-  platform_version = "1.3.0"
   launch_type      = "FARGATE"
   desired_count    = var.fargate_count
   cluster          = var.cluster_id

--- a/modules/grafana/service.tf
+++ b/modules/grafana/service.tf
@@ -92,10 +92,10 @@ resource "aws_ecs_task_definition" "grafana_task_definition" {
 resource "aws_ecs_service" "grafana_ecs_service" {
   name = "${var.prefix_pttp}-grafana-ecs-service"
 
-  launch_type      = "FARGATE"
-  desired_count    = var.fargate_count
-  cluster          = var.cluster_id
-  task_definition  = aws_ecs_task_definition.grafana_task_definition.arn
+  launch_type     = "FARGATE"
+  desired_count   = var.fargate_count
+  cluster         = var.cluster_id
+  task_definition = aws_ecs_task_definition.grafana_task_definition.arn
 
   network_configuration {
     subnets         = var.private_subnet_ids


### PR DESCRIPTION
Removing specified version number for ECS so it will use the latest version by default