### PR TITLE
:passport_control: allowing public and private subnets to blackbox and SNMP

### DIFF
--- a/modules/blackbox_exporter/security_groups.tf
+++ b/modules/blackbox_exporter/security_groups.tf
@@ -35,7 +35,7 @@ resource "aws_security_group" "lb_blackbox_exporter" {
     protocol    = "tcp"
     from_port   = var.fargate_port
     to_port     = var.fargate_port
-    cidr_blocks = data.aws_subnet.private_subnets.*.cidr_block
+    cidr_blocks = concat(data.aws_subnet.private_subnets.*.cidr_block, data.aws_subnet.private_subnets.*.cidr_block)
   }
 
   egress {

--- a/modules/snmp_exporter/security_groups.tf
+++ b/modules/snmp_exporter/security_groups.tf
@@ -35,7 +35,7 @@ resource "aws_security_group" "lb_snmp_exporter" {
     protocol    = "tcp"
     from_port   = var.fargate_port
     to_port     = var.fargate_port
-    cidr_blocks = data.aws_subnet.private_subnets.*.cidr_block
+    cidr_blocks = concat(data.aws_subnet.private_subnets.*.cidr_block, data.aws_subnet.private_subnets.*.cidr_block)
   }
 
   egress {


### PR DESCRIPTION
Allowing public and private VPC IPs to access the Blackbox and SNMP exporters until the EKS cluster is rebuilt with stricter IP settings.