### PR TITLE
:wrench:PTTP-8592-Upgrade-EKS-1.19to1.20

### DIFF
--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -3,7 +3,7 @@ module "monitoring_alerting_cluster" {
   version                         = "14.0.0"
   create_eks                      = var.is_eks_enabled
   cluster_name                    = "${var.prefix}-cluster"
-  cluster_version                 = "1.19"
+  cluster_version                 = "1.20"
   manage_aws_auth                 = false
   cluster_endpoint_private_access = true
   cluster_enabled_log_types       = ["api", "authenticator", "controllerManager"]


### PR DESCRIPTION
User Story:
As CloudOps engineers 
I want to be on a more current version of EKS
So that we don’t fall behind on versions, as AWS will stop the support of older versions at some point.

Value / Purpose  
This will identify any deprecations that may affect code and deployments. This will also make us better prepared of dependencies that may arise.

Useful Contacts
CloudOps Team