### PR TITLE
:wrench: Update EKS Cluster to v1.21

### DIFF
--- a/modules/monitoring_platform/eks.tf
+++ b/modules/monitoring_platform/eks.tf
@@ -3,7 +3,7 @@ module "monitoring_alerting_cluster" {
   version                         = "14.0.0"
   create_eks                      = var.is_eks_enabled
   cluster_name                    = "${var.prefix}-cluster"
-  cluster_version                 = "1.20"
+  cluster_version                 = "1.21"
   manage_aws_auth                 = false
   cluster_endpoint_private_access = true
   cluster_enabled_log_types       = ["api", "authenticator", "controllerManager"]


### PR DESCRIPTION
This change follows [this](https://github.com/ministryofjustice/staff-infrastructure-monitoring/commit/d61ede47813c3aa139aa22ef3db5237710f11df0) commit, and upgrades the running EKS version from 1.20 to 1.21. 