### PR TITLE
:sparkles: Add thanos receiver certificate Config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -61,6 +61,7 @@ module "label_mojo" {
 module "monitoring_platform_v2" {
   source = "./modules/monitoring_platform"
 
+  env    = module.label_mojo.stage  
   prefix = module.label_mojo.id
   tags   = module.label_mojo.tags
 
@@ -95,6 +96,8 @@ module "monitoring_platform_v2" {
   corsham_5260_ip            = var.corsham_5260_ip
   corsham_mgmt_range         = "${var.corsham_mgmt_range}.0/24"
   farnborough_mgmt_range     = "${var.farnborough_mgmt_range}.0/24"
+
+  vpn_hosted_zone_domain = var.vpn_hosted_zone_domain
 
   providers = {
     aws = aws.env

--- a/main.tf
+++ b/main.tf
@@ -61,7 +61,7 @@ module "label_mojo" {
 module "monitoring_platform_v2" {
   source = "./modules/monitoring_platform"
 
-  env    = module.label_mojo.stage  
+  env    = module.label_mojo.stage
   prefix = module.label_mojo.id
   tags   = module.label_mojo.tags
 

--- a/modules/monitoring_platform/certificates.tf
+++ b/modules/monitoring_platform/certificates.tf
@@ -1,0 +1,10 @@
+resource "aws_acm_certificate" "thanos_receiver" {
+  domain_name       = "thanos-secure-${var.env}.${var.vpn_hosted_zone_domain}"
+  validation_method = "DNS"
+
+  tags = var.tags
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/monitoring_platform/outputs.tf
+++ b/modules/monitoring_platform/outputs.tf
@@ -49,3 +49,7 @@ output "eks_cluster_worker_iam_role_arn" {
 output "cloudwatch_access_policy" {
   value = aws_iam_policy.cloudwatch_access_eks_policy.arn
 }
+
+output "thanos_secure_certificate_name" {
+  value = module.aws_acm_certificate.thanos_receiver.domain_name
+}

--- a/modules/monitoring_platform/outputs.tf
+++ b/modules/monitoring_platform/outputs.tf
@@ -51,5 +51,5 @@ output "cloudwatch_access_policy" {
 }
 
 output "thanos_secure_certificate_name" {
-  value = module.aws_acm_certificate.thanos_receiver.domain_name
+  value = aws_acm_certificate.thanos_receiver.domain_name
 }

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -119,3 +119,11 @@ variable "corsham_mgmt_range" {
 variable "farnborough_mgmt_range" {
   type = string
 }
+
+variable "env" {
+  type = string
+}
+
+variable "vpn_hosted_zone_domain" {
+  type = string
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -79,6 +79,10 @@ output "eks_cluster_worker_iam_role_arn" {
   value = module.monitoring_platform_v2.eks_cluster_worker_iam_role_arn
 }
 
+output "thanos_secure_certificate_name" {
+  value = module.monitoring_platform_v2.aws_acm_certificate.thanos_receiver.domain_name
+}
+
 output "prometheus_thanos_storage_bucket_name" {
   value = module.prometheus-thanos-store.bucket_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,7 +80,7 @@ output "eks_cluster_worker_iam_role_arn" {
 }
 
 output "thanos_secure_certificate_name" {
-  value = module.monitoring_platform_v2.thanos_receiver_certificate_name
+  value = module.monitoring_platform_v2.thanos_secure_certificate_name
 }
 
 output "prometheus_thanos_storage_bucket_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -80,7 +80,7 @@ output "eks_cluster_worker_iam_role_arn" {
 }
 
 output "thanos_secure_certificate_name" {
-  value = module.monitoring_platform_v2.aws_acm_certificate.thanos_receiver.domain_name
+  value = module.monitoring_platform_v2.thanos_receiver_certificate_name
 }
 
 output "prometheus_thanos_storage_bucket_name" {


### PR DESCRIPTION
This PR has been raised in relation to this issue: ministryofjustice/staff-infrastructure-monitoring-deployments#78 

This configuration seeks to add a certificate which will be used in conjunction with an nginx proxy to pass ALZ traffic to the IMA platform. 