### PR TITLE
:pencil2: Edit thanos_receiver cert name

### DIFF
--- a/modules/monitoring_platform/certificates.tf
+++ b/modules/monitoring_platform/certificates.tf
@@ -1,5 +1,5 @@
 resource "aws_acm_certificate" "thanos_receiver" {
-  domain_name       = "thanos-secure-${var.env}.${var.vpn_hosted_zone_domain}"
+  domain_name       = "thanos-secure.${var.vpn_hosted_zone_domain}"
   validation_method = "DNS"
 
   tags = var.tags


### PR DESCRIPTION
`thanos-secure-development.dev.staff.service.justice.gov.uk` will now appear as `thanos-secure.dev.staff.service.justice.gov.uk` thereby removing the double mention of development. 