### PR TITLE
:wrench: Update grafana-lb ingress ports

### DIFF
--- a/modules/grafana/security_groups.tf
+++ b/modules/grafana/security_groups.tf
@@ -28,6 +28,13 @@ resource "aws_security_group" "lb_grafana" {
   ingress {
     protocol    = "tcp"
     from_port   = var.host_port
+    to_port     = var.host_port
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    protocol    = "tcp"
+    from_port   = var.container_port
     to_port     = var.container_port
     cidr_blocks = ["0.0.0.0/0"]
   }


### PR DESCRIPTION
The purpose of this PR is to change the ingress ports used in the `lb_grafana` security group. 

At the moment the entire range from port 443 to 3000 is open in the security group. 

This PR seeks to resolve this by creating another ingress module (right terminology?) in `security_groups.tf` which opens up port 3000 and refactoring the original egress module (?) to open port 443. 

TLDR: (Range 443 up to and including 3000) -> (port 443 + 3000) 