### PR TITLE
:lock: Locking down DB access to only VPC CIDR block

### DIFF
--- a/modules/grafana/security_groups.tf
+++ b/modules/grafana/security_groups.tf
@@ -65,7 +65,7 @@ resource "aws_security_group" "db_in" {
     protocol    = "tcp"
     from_port   = var.db_port
     to_port     = var.db_port
-    cidr_blocks = ["0.0.0.0/0"]
+    cidr_blocks = [var.vpc_cidr_range]
   }
 
   tags = var.tags


### PR DESCRIPTION
As per Trusted Advisor recommendation in [this](https://github.com/ministryofjustice/staff-infrastructure-monitoring/issues/173) ticket, this PR locks down the range from 0.0.0.0/0 to the relevant VPC CIDR block.