### PR TITLE
:bricks: add byoip to nat gateways

### DIFF
--- a/buildspec.yml
+++ b/buildspec.yml
@@ -12,6 +12,7 @@ env:
     SHARED_SERVICES_ACCOUNT_ID: "/codebuild/staff_device_shared_services_account_id"
     TF_VAR_production_account_id: "/codebuild/pttp-ci-ima-pipeline/production_account_id"
     TF_VAR_assume_role: "/codebuild/pttp-ci-ima-pipeline/$ENV/assume_role"
+    TF_VAR_byoip_pool_id: "/staff-device/dns/$ENV/public_ip_pool_id"
     TF_VAR_grafana_db_name: "/codebuild/pttp-ci-ima-pipeline/$ENV/grafana_db_name"
     TF_VAR_grafana_db_endpoint: "/codebuild/pttp-ci-ima-pipeline/$ENV/grafana_db_endpoint"
     TF_VAR_grafana_db_endpoint_v2: "/codebuild/pttp-ci-ima-pipeline/$ENV/grafana_db_endpoint_v2"

--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,7 @@ module "monitoring_platform_v2" {
   vpc_flow_log_bucket_arn = module.vpc_flow_logging.bucket_arn
 
   cloudwatch_exporter_access_role_arns = compact(split(",", trimspace(var.cloudwatch_exporter_access_role_arns)))
+  byoip_pool_id                        = var.byoip_pool_id
 
   enable_ima_dns_resolver    = var.enable_ima_dns_resolver
   gsi_domain                 = var.gsi_domain

--- a/modules/monitoring_platform/network.tf
+++ b/modules/monitoring_platform/network.tf
@@ -178,8 +178,10 @@ resource "aws_route" "farnborough_mgmt" {
 
 # Create a NAT gateway with an EIP for each private subnet to get internet connectivity
 resource "aws_eip" "gw" {
-  vpc        = true
-  count      = var.az_count
+  vpc              = true
+  count            = var.az_count
+  public_ipv4_pool = var.byoip_pool_id
+
   depends_on = [aws_internet_gateway.gw]
 
   tags = var.tags

--- a/modules/monitoring_platform/variables.tf
+++ b/modules/monitoring_platform/variables.tf
@@ -29,6 +29,10 @@ variable "transit_gateway_route_table_id" {
   type = string
 }
 
+variable "byoip_pool_id" {
+  type = string
+}
+
 variable "vpc_cidr_block" {
   type = string
 }

--- a/variables.tf
+++ b/variables.tf
@@ -200,3 +200,7 @@ variable "quantum_dns_ip_1" {
 variable "quantum_dns_ip_2" {
   type = string
 }
+
+variable "byoip_pool_id" {
+  type = string
+}


### PR DESCRIPTION
This PR will add IPs from the BYOIP pool to the IMA VPC NAT gateway.  This will allow Prometheus and co to scrape internal MoJ resources,